### PR TITLE
Fix symbols references

### DIFF
--- a/biscuit.go
+++ b/biscuit.go
@@ -41,10 +41,12 @@ var (
 	ErrUnknownPublicKey = errors.New("biscuit: unknown public key")
 )
 
-func New(rng io.Reader, root sig.Keypair, symbols *datalog.SymbolTable, authority *Block) (*Biscuit, error) {
+func New(rng io.Reader, root sig.Keypair, baseSymbols *datalog.SymbolTable, authority *Block) (*Biscuit, error) {
 	if rng == nil {
 		rng = rand.Reader
 	}
+
+	symbols := baseSymbols.Clone()
 
 	if !symbols.IsDisjoint(authority.symbols) {
 		return nil, ErrSymbolTableOverlap

--- a/biscuit_test.go
+++ b/biscuit_test.go
@@ -255,7 +255,7 @@ func TestGenerateWorld(t *testing.T) {
 	require.NoError(t, err)
 
 	symbolTable := (build.(*builder)).symbols
-	world, err := b.generateWorld(DefaultSymbolTable)
+	world, err := b.generateWorld(defaultSymbolTable.Clone())
 	require.NoError(t, err)
 
 	expectedWorld := datalog.NewWorld()

--- a/builder.go
+++ b/builder.go
@@ -35,7 +35,7 @@ type builder struct {
 }
 
 func NewBuilder(rng io.Reader, root sig.Keypair) Builder {
-	return BuilderWithSymbols(rng, root, DefaultSymbolTable)
+	return BuilderWithSymbols(rng, root, defaultSymbolTable)
 }
 
 func BuilderWithSymbols(rng io.Reader, root sig.Keypair, symbols *datalog.SymbolTable) Builder {
@@ -44,7 +44,7 @@ func BuilderWithSymbols(rng io.Reader, root sig.Keypair, symbols *datalog.Symbol
 		root: root,
 
 		symbolsStart: symbols.Len(),
-		symbols:      symbols,
+		symbols:      symbols.Clone(),
 		facts:        new(datalog.FactSet),
 	}
 }
@@ -100,10 +100,8 @@ type Unmarshaler struct {
 	Symbols *datalog.SymbolTable
 }
 
-var defaultUnmarshaler = &Unmarshaler{Symbols: DefaultSymbolTable}
-
 func Unmarshal(serialized []byte) (*Biscuit, error) {
-	return defaultUnmarshaler.Unmarshal(serialized)
+	return (&Unmarshaler{Symbols: defaultSymbolTable.Clone()}).Unmarshal(serialized)
 }
 
 func (u *Unmarshaler) Unmarshal(serialized []byte) (*Biscuit, error) {

--- a/datalog/datalog_test.go
+++ b/datalog/datalog_test.go
@@ -470,3 +470,39 @@ func TestSymbolTable(t *testing.T) {
 	require.Equal(t, s3, new)
 	require.Equal(t, s2, s1)
 }
+
+func TestSymbolTableInsertAndSym(t *testing.T) {
+	s := new(SymbolTable)
+	require.Equal(t, Symbol(0), s.Insert("a"))
+	require.Equal(t, Symbol(1), s.Insert("b"))
+	require.Equal(t, Symbol(2), s.Insert("c"))
+
+	require.Equal(t, &SymbolTable{"a", "b", "c"}, s)
+
+	require.Equal(t, Symbol(0), s.Insert("a"))
+	require.Equal(t, Symbol(3), s.Insert("d"))
+
+	require.Equal(t, &SymbolTable{"a", "b", "c", "d"}, s)
+
+	require.Equal(t, Symbol(0), s.Sym("a"))
+	require.Equal(t, Symbol(1), s.Sym("b"))
+	require.Equal(t, Symbol(2), s.Sym("c"))
+	require.Equal(t, Symbol(3), s.Sym("d"))
+	require.Equal(t, nil, s.Sym("e"))
+}
+
+func TestSymbolTableClone(t *testing.T) {
+	s := new(SymbolTable)
+
+	s.Insert("a")
+	s.Insert("b")
+	s.Insert("c")
+
+	s2 := s.Clone()
+	s2.Insert("a")
+	s2.Insert("d")
+	s2.Insert("e")
+
+	require.Equal(t, &SymbolTable{"a", "b", "c"}, s)
+	require.Equal(t, &SymbolTable{"a", "b", "c", "d", "e"}, s2)
+}

--- a/datalog/datalog_test.go
+++ b/datalog/datalog_test.go
@@ -6,6 +6,8 @@ import (
 	"regexp"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func hashVar(s string) Variable {
@@ -448,4 +450,23 @@ func TestCheckers(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestSymbolTable(t *testing.T) {
+	s1 := new(SymbolTable)
+	s2 := &SymbolTable{"a", "b", "c"}
+	s3 := &SymbolTable{"d", "e", "f"}
+
+	require.True(t, s1.IsDisjoint(s2))
+	s1.Extend(s2)
+	require.False(t, s1.IsDisjoint(s2))
+	require.Equal(t, s2, s1)
+	s1.Extend(s3)
+	require.Equal(t, SymbolTable(append(*s2, *s3...)), *s1)
+
+	require.Equal(t, len(*s2)+len(*s3), s1.Len())
+
+	new := s1.SplitOff(len(*s2))
+	require.Equal(t, s3, new)
+	require.Equal(t, s2, s1)
 }

--- a/example_test.go
+++ b/example_test.go
@@ -125,7 +125,7 @@ func ExampleBiscuit() {
 		fmt.Println("verified token")
 	}
 
-	// Output: Token1 length: 226
-	// Token2 length: 370
+	// Output: Token1 length: 240
+	// Token2 length: 384
 	// verified token
 }

--- a/types.go
+++ b/types.go
@@ -12,9 +12,9 @@ import (
 
 const SymbolAuthority = Symbol("authority")
 
-// DefaultSymbolTable predefines some symbols available in every implementation, to avoid
+// defaultSymbolTable predefines some symbols available in every implementation, to avoid
 // transmitting them with every token
-var DefaultSymbolTable = &datalog.SymbolTable{
+var defaultSymbolTable = &datalog.SymbolTable{
 	"authority",
 	"ambient",
 	"resource",


### PR DESCRIPTION
Fix an issue where the defaultSymbolTable get modified due to shared references used in the biscuit builder and unmarshaller, ending getting biscuits with invalid symbols / blocks with empty symbol table. 