### PR TITLE
Add verifier GetBlockID

### DIFF
--- a/biscuit.go
+++ b/biscuit.go
@@ -181,15 +181,20 @@ func (b *Biscuit) SHA256Sum(count int) ([]byte, error) {
 	}
 
 	h := sha256.New()
+	// write the authority block and the root key
 	if _, err := h.Write(b.container.Authority); err != nil {
 		return nil, err
 	}
+	if _, err := h.Write(b.container.Keys[0]); err != nil {
+		return nil, err
+	}
+
 	for _, block := range b.container.Blocks[:count] {
 		if _, err := h.Write(block); err != nil {
 			return nil, err
 		}
 	}
-	for _, key := range b.container.Keys[:count+1] { // +1 for the root key
+	for _, key := range b.container.Keys[:count+1] { // +1 to skip the root key
 		if _, err := h.Write(key); err != nil {
 			return nil, err
 		}

--- a/experiments/pop_test.go
+++ b/experiments/pop_test.go
@@ -285,7 +285,14 @@ func verifySignature(t *testing.T, rootPubKey sig.PublicKey, b []byte) {
 	signerTimestamp, ok := toValidate[0].IDs[6].(biscuit.Date)
 	require.True(t, ok)
 
-	signedTokenHash, err := token.SHA256Sum(token.BlockCount() - 1)
+	// retrieve the block index containing user signature
+	blockIdx, err := verifier.GetBlockID(biscuit.Fact{Predicate: biscuit.Predicate{
+		Name: "signature",
+		IDs:  []biscuit.Atom{dataID, pubkey, signature, signerNonce, signerTimestamp},
+	}})
+	require.NoError(t, err)
+	// the signedTokenHash is on all the blocks before the one containing the signature.
+	signedTokenHash, err := token.SHA256Sum(blockIdx - 1)
 	require.NoError(t, err)
 
 	// Reconstruct signed data with all the above properties

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,7 @@ github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrU
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:WU3c8KckQ9AFe+yFwt9sWVRKCVIyN9cPHBJSNnbL67w=
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
-github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0=
-github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
+github.com/golang/protobuf v1.4.3 h1:JjCZWpVbqXDqFVmTfYWEVTMIYrL/NPdPSCHPJ0T/raM=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=

--- a/verifier.go
+++ b/verifier.go
@@ -10,6 +10,7 @@ import (
 
 var (
 	ErrMissingSymbols = errors.New("biscuit: missing symbols")
+	ErrFactNotFound   = errors.New("biscuit: fact not found")
 )
 
 type Verifier interface {
@@ -139,10 +140,10 @@ func (v *verifier) Query(rule Rule) (FactSet, error) {
 	return result, nil
 }
 
-// GetBlockID returns the first block index containing a fact with the given name
-// starting from the authority block and then moving on other blocks in order they were added.
-// Note that facts generated from rules can't be searched
-// An error is returned when no fact with the given name can be found.
+// GetBlockID returns the first block index containing a fact
+// starting from the authority block and then each block in order they were added.
+// Note that facts generated from rules can't be searched.
+// An error is returned when no matching fact is found.
 func (v *verifier) GetBlockID(fact Fact) (int, error) {
 	// don't store symbols from searched fact in the verifier table
 	symbols := v.symbols.Clone()
@@ -162,7 +163,7 @@ func (v *verifier) GetBlockID(fact Fact) (int, error) {
 		}
 	}
 
-	return 0, fmt.Errorf("fact %q not found", fact)
+	return 0, ErrFactNotFound
 }
 
 func (v *verifier) PrintWorld() string {

--- a/verifier.go
+++ b/verifier.go
@@ -143,7 +143,7 @@ func (v *verifier) Query(rule Rule) (FactSet, error) {
 // GetBlockID returns the first block index containing a fact
 // starting from the authority block and then each block in order they were added.
 // Note that facts generated from rules can't be searched.
-// An error is returned when no matching fact is found.
+// ErrFactNotFound is returned when no matching fact is found.
 func (v *verifier) GetBlockID(fact Fact) (int, error) {
 	// don't store symbols from searched fact in the verifier table
 	symbols := v.symbols.Clone()

--- a/verifier_test.go
+++ b/verifier_test.go
@@ -1,0 +1,84 @@
+package biscuit
+
+import (
+	"crypto/rand"
+	"fmt"
+	"testing"
+
+	"github.com/flynn/biscuit-go/sig"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetBlockID(t *testing.T) {
+	rng := rand.Reader
+	root := sig.GenerateKeypair(rng)
+	builder := NewBuilder(rng, root)
+
+	// add 3 facts authority_0_fact_{0,1,2} in authority block
+	for i := 0; i < 3; i++ {
+		require.NoError(t, builder.AddAuthorityFact(Fact{Predicate: Predicate{
+			Name: fmt.Sprintf("authority_0_fact_%d", i),
+			IDs:  []Atom{Integer(i)},
+		}}))
+	}
+
+	b, err := builder.Build()
+	require.NoError(t, err)
+	// add 2 extra blocks each containing 3 facts block_{0,1}_fact_{0,1,2}
+	for i := 0; i < 2; i++ {
+		blockBuilder := b.CreateBlock()
+		for j := 0; j < 3; j++ {
+			blockBuilder.AddFact(Fact{Predicate: Predicate{
+				Name: fmt.Sprintf("block_%d_fact_%d", i, j),
+				IDs:  []Atom{Symbol("block"), Integer(i), Integer(j)},
+			}})
+		}
+		b, err = b.Append(rng, sig.GenerateKeypair(rng), blockBuilder.Build())
+		require.NoError(t, err)
+	}
+
+	v, err := b.Verify(root.Public())
+	require.NoError(t, err)
+
+	idx, err := v.GetBlockID(Fact{Predicate{
+		Name: "authority_0_fact_0",
+		IDs:  []Atom{Symbol("authority"), Integer(0)},
+	}})
+	require.NoError(t, err)
+	require.Equal(t, 0, idx)
+	idx, err = v.GetBlockID(Fact{Predicate{
+		Name: "authority_0_fact_2",
+		IDs:  []Atom{Symbol("authority"), Integer(2)},
+	}})
+	require.NoError(t, err)
+	require.Equal(t, 0, idx)
+
+	idx, err = v.GetBlockID(Fact{Predicate{
+		Name: "block_0_fact_2",
+		IDs:  []Atom{Symbol("block"), Integer(0), Integer(2)},
+	}})
+	require.NoError(t, err)
+	require.Equal(t, 1, idx)
+	idx, err = v.GetBlockID(Fact{Predicate{
+		Name: "block_1_fact_1",
+		IDs:  []Atom{Symbol("block"), Integer(1), Integer(1)},
+	}})
+	require.NoError(t, err)
+	require.Equal(t, 2, idx)
+
+	_, err = v.GetBlockID(Fact{Predicate{
+		Name: "block_1_fact_3",
+		IDs:  []Atom{Symbol("block"), Integer(1), Integer(3)},
+	}})
+	require.Error(t, err)
+	_, err = v.GetBlockID(Fact{Predicate{
+		Name: "block_2_fact_1",
+		IDs:  []Atom{Symbol("block"), Integer(2), Integer(1)},
+	}})
+	require.Error(t, err)
+	_, err = v.GetBlockID(Fact{Predicate{
+		Name: "block_1_fact_1",
+		IDs:  []Atom{Integer(1), Integer(1)},
+	}})
+	require.Error(t, err)
+}

--- a/verifier_test.go
+++ b/verifier_test.go
@@ -70,15 +70,15 @@ func TestGetBlockID(t *testing.T) {
 		Name: "block_1_fact_3",
 		IDs:  []Atom{Symbol("block"), Integer(1), Integer(3)},
 	}})
-	require.Error(t, err)
+	require.Equal(t, ErrFactNotFound, err)
 	_, err = v.GetBlockID(Fact{Predicate{
 		Name: "block_2_fact_1",
 		IDs:  []Atom{Symbol("block"), Integer(2), Integer(1)},
 	}})
-	require.Error(t, err)
+	require.Equal(t, ErrFactNotFound, err)
 	_, err = v.GetBlockID(Fact{Predicate{
 		Name: "block_1_fact_1",
 		IDs:  []Atom{Integer(1), Integer(1)},
 	}})
-	require.Error(t, err)
+	require.Equal(t, ErrFactNotFound, err)
 }


### PR DESCRIPTION
This allows to search for a block containing a specific fact name, and
retrieve it's index. This is useful in proof of possession flow, where
the verifier needs to hash all the blocks before the one containing the
user signature.

Also fixed the `biscuit.SHA256Sum` function which were not including 
the root key in the hash.