### PR TITLE
remove verifier addResource, addOperation and setTime

### DIFF
--- a/biscuit_test.go
+++ b/biscuit_test.go
@@ -87,18 +87,18 @@ func TestBiscuit(t *testing.T) {
 	v3, err := b3deser.Verify(root.Public())
 	require.NoError(t, err)
 
-	v3.AddOperation("read")
-	v3.AddResource("/a/file1")
+	v3.AddFact(Fact{Predicate: Predicate{Name: "resource", IDs: []Atom{Symbol("ambient"), String("/a/file1")}}})
+	v3.AddFact(Fact{Predicate: Predicate{Name: "operation", IDs: []Atom{Symbol("ambient"), Symbol("read")}}})
 	require.NoError(t, v3.Verify())
 
 	v3.Reset()
-	v3.AddOperation("read")
-	v3.AddResource("/a/file2")
+	v3.AddFact(Fact{Predicate: Predicate{Name: "resource", IDs: []Atom{Symbol("ambient"), Symbol("/a/file2")}}})
+	v3.AddFact(Fact{Predicate: Predicate{Name: "operation", IDs: []Atom{Symbol("ambient"), Symbol("read")}}})
 	require.Error(t, v3.Verify())
 
 	v3.Reset()
-	v3.AddOperation("write")
-	v3.AddResource("/a/file1")
+	v3.AddFact(Fact{Predicate: Predicate{Name: "resource", IDs: []Atom{Symbol("ambient"), Symbol("/a/file1")}}})
+	v3.AddFact(Fact{Predicate: Predicate{Name: "operation", IDs: []Atom{Symbol("ambient"), Symbol("write")}}})
 	require.Error(t, v3.Verify())
 }
 
@@ -181,8 +181,8 @@ func TestBiscuitRules(t *testing.T) {
 func verifyOwner(t *testing.T, v Verifier, owners map[string]bool) {
 	for user, valid := range owners {
 		t.Run(fmt.Sprintf("verify owner %s", user), func(t *testing.T) {
-			v.AddOperation("write")
-			v.AddResource("file1")
+			v.AddFact(Fact{Predicate: Predicate{Name: "resource", IDs: []Atom{Symbol("ambient"), String("file1")}}})
+			v.AddFact(Fact{Predicate: Predicate{Name: "operation", IDs: []Atom{Symbol("ambient"), Symbol("write")}}})
 			v.AddFact(Fact{
 				Predicate: Predicate{
 					Name: "owner",

--- a/example_test.go
+++ b/example_test.go
@@ -116,8 +116,8 @@ func ExampleBiscuit() {
 		panic(fmt.Errorf("failed to create verifier: %v", err))
 	}
 
-	v1.AddResource("/a/file1.txt")
-	v1.AddOperation("read")
+	v1.AddFact(biscuit.Fact{Predicate: biscuit.Predicate{Name: "resource", IDs: []biscuit.Atom{biscuit.Symbol("ambient"), biscuit.String("/a/file1.txt")}}})
+	v1.AddFact(biscuit.Fact{Predicate: biscuit.Predicate{Name: "operation", IDs: []biscuit.Atom{biscuit.Symbol("ambient"), biscuit.Symbol("read")}}})
 
 	if err := v1.Verify(); err != nil {
 		fmt.Printf("failed to verify token: %v\n", err)

--- a/verifier.go
+++ b/verifier.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/flynn/biscuit-go/datalog"
 )
@@ -14,9 +13,6 @@ var (
 )
 
 type Verifier interface {
-	AddResource(res string)
-	AddOperation(op string)
-	SetTime(t time.Time)
 	AddFact(fact Fact)
 	AddRule(rule Rule)
 	AddCaveat(caveat Caveat)
@@ -51,45 +47,6 @@ func NewVerifier(b *Biscuit) (Verifier, error) {
 		symbols:     b.symbols.Clone(),
 		caveats:     []Caveat{},
 	}, nil
-}
-
-func (v *verifier) AddResource(res string) {
-	fact := Fact{
-		Predicate: Predicate{
-			Name: "resource",
-			IDs: []Atom{
-				Symbol("ambient"),
-				String(res),
-			},
-		},
-	}
-	v.world.AddFact(fact.convert(v.symbols))
-}
-
-func (v *verifier) AddOperation(op string) {
-	fact := Fact{
-		Predicate: Predicate{
-			Name: "operation",
-			IDs: []Atom{
-				Symbol("ambient"),
-				Symbol(op),
-			},
-		},
-	}
-	v.world.AddFact(fact.convert(v.symbols))
-}
-
-func (v *verifier) SetTime(t time.Time) {
-	fact := Fact{
-		Predicate: Predicate{
-			Name: "time",
-			IDs: []Atom{
-				Symbol("ambient"),
-				Date(t),
-			},
-		},
-	}
-	v.world.AddFact(fact.convert(v.symbols))
 }
 
 func (v *verifier) AddFact(fact Fact) {


### PR DESCRIPTION
Those methods doesn't belong to the general verifier interface,
and depends on the biscuit usage context. A custom verifier
have been added in example, showing how to extend the generic
one with similar helpers.