### PR TITLE
update golangci/golangci-lint-action to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@c238b72278d97934fd2cb007b97162d5b44757df
+        uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.28
-


### PR DESCRIPTION
Update golanci-lint version to get ride of the set-env and add-path warnings (see https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/)