### PR TITLE
Update parser grammar

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/alecthomas/participle/v2 v2.0.0-alpha3.0.20201208114601-14bec2482095 h1:DCGcCFtR/4YWEOoszqekJRdDoq41G+btPdOSWf5FoSo=
+github.com/alecthomas/participle/v2 v2.0.0-alpha3.0.20201208114601-14bec2482095 h1:DCGcCFtR/4YWEOoszqekJRdDoq41G+btPdOSWf5FoSo=
+github.com/alecthomas/participle/v2 v2.0.0-alpha3.0.20201208114601-14bec2482095/go.mod h1:Z1zPLDbcGsVsBYsThKXY00i84575bN/nMczzIrU4rWU=
 github.com/alecthomas/participle/v2 v2.0.0-alpha3.0.20201208114601-14bec2482095/go.mod h1:Z1zPLDbcGsVsBYsThKXY00i84575bN/nMczzIrU4rWU=
 github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1 h1:GDQdwm/gAcJcLAKQQZGOJ4knlw+7rfEQQcmwTbt4p5E=
 github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1/go.mod h1:xTS7Pm1pD1mvyM075QCDSRqH6qRLXylzS24ZTpRiSzQ=

--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,8 @@
-<<<<<<< Updated upstream
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/alecthomas/participle v0.6.0 h1:Pvo8XUCQKgIywVjz/+Ci3IsjGg+g/TdKkMcfgghKCEw=
-github.com/alecthomas/participle v0.6.0/go.mod h1:HfdmEuwvr12HXQN44HPWXR0lHmVolVYe4dyL6lQ3duY=
-github.com/alecthomas/participle v0.7.1 h1:2bN7reTw//5f0cugJcTOnY/NYZcWQOaajW+BwZB5xWs=
-github.com/alecthomas/participle/v2 v2.0.0-alpha1 h1:ouqZsiwVYbyl4liVrbU7BaVxqnhF3me8wJ+kW0uEiv8=
-github.com/alecthomas/participle/v2 v2.0.0-alpha1/go.mod h1:kPFs05qle86ZkCGXcLcM72PNESH6DA4YJUDn/ebwPyw=
 github.com/alecthomas/participle/v2 v2.0.0-alpha3.0.20201208114601-14bec2482095 h1:DCGcCFtR/4YWEOoszqekJRdDoq41G+btPdOSWf5FoSo=
 github.com/alecthomas/participle/v2 v2.0.0-alpha3.0.20201208114601-14bec2482095/go.mod h1:Z1zPLDbcGsVsBYsThKXY00i84575bN/nMczzIrU4rWU=
+github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1 h1:GDQdwm/gAcJcLAKQQZGOJ4knlw+7rfEQQcmwTbt4p5E=
 github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1/go.mod h1:xTS7Pm1pD1mvyM075QCDSRqH6qRLXylzS24ZTpRiSzQ=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -32,6 +27,7 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/gtank/ristretto255 v0.1.2 h1:JEqUCPA1NvLq5DwYtuzigd7ss8fwbYay9fi4/5uMzcc=
 github.com/gtank/ristretto255 v0.1.2/go.mod h1:Ph5OpO6c7xKUGROZfWVLiJf9icMDwUeIvY4OmlYW69o=
@@ -62,6 +58,7 @@ golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -81,6 +78,7 @@ google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=

--- a/parser/grammar.go
+++ b/parser/grammar.go
@@ -14,6 +14,19 @@ import (
 	"github.com/flynn/biscuit-go/datalog"
 )
 
+type Comment string
+
+func (c *Comment) Capture(values []string) error {
+	if len(values) != 1 {
+		return errors.New("parser: invalid comment values")
+	}
+	if !strings.HasPrefix(values[0], "//") {
+		return errors.New("parser: invalid comment prefix")
+	}
+	*c = Comment(strings.TrimSpace(strings.TrimPrefix(values[0], "//")))
+	return nil
+}
+
 type Symbol string
 
 func (s *Symbol) Capture(values []string) error {
@@ -41,7 +54,7 @@ func (v *Variable) Capture(values []string) error {
 }
 
 type Rule struct {
-	Comments    []string      `@Comment*`
+	Comments    []*Comment    `@Comment*`
 	Head        *Predicate    `"*" @@`
 	Body        []*Predicate  `"<-" @@ ("," @@)*`
 	Constraints []*Constraint `("@" @@ ("," @@)*)*`

--- a/parser/grammar.go
+++ b/parser/grammar.go
@@ -139,6 +139,10 @@ func (h *HexString) Decode() ([]byte, error) {
 	return hex.DecodeString(string(*h))
 }
 
+func (h *HexString) String() string {
+	return string(*h)
+}
+
 func (p *Predicate) ToBiscuit() (*biscuit.Predicate, error) {
 	atoms := make([]biscuit.Atom, 0, len(p.IDs))
 	for _, a := range p.IDs {

--- a/parser/grammar_test.go
+++ b/parser/grammar_test.go
@@ -18,61 +18,61 @@ func TestGrammarPredicate(t *testing.T) {
 		{
 			Input: `resource(#ambient, $var1)`,
 			Expected: &Predicate{
-				Name: "resource",
+				Name: sptr("resource"),
 				IDs: []*Atom{
-					{Symbol: sptr("ambient")},
-					{Variable: sptr("var1")},
+					{Symbol: symptr("ambient")},
+					{Variable: varptr("var1")},
 				},
 			},
 		},
 		{
 			Input: `resource(#ambient, $0, #read)`,
 			Expected: &Predicate{
-				Name: "resource",
+				Name: sptr("resource"),
 				IDs: []*Atom{
-					{Symbol: sptr("ambient")},
-					{Variable: sptr("0")},
-					{Symbol: sptr("read")},
+					{Symbol: symptr("ambient")},
+					{Variable: varptr("0")},
+					{Symbol: symptr("read")},
 				},
 			},
 		},
 		{
 			Input: `right(#authority, "/a/file1.txt", #read)`,
 			Expected: &Predicate{
-				Name: "right",
+				Name: sptr("right"),
 				IDs: []*Atom{
-					{Symbol: sptr("authority")},
+					{Symbol: symptr("authority")},
 					{String: sptr("/a/file1.txt")},
-					{Symbol: sptr("read")},
+					{Symbol: symptr("read")},
 				},
 			},
 		},
 		{
 			Input: `right("/a/file1.txt", #read)`,
 			Expected: &Predicate{
-				Name: "right",
+				Name: sptr("right"),
 				IDs: []*Atom{
 					{String: sptr("/a/file1.txt")},
-					{Symbol: sptr("read")},
+					{Symbol: symptr("read")},
 				},
 			},
 		},
 		{
 			Input: `right("/a/file1.txt", $1)`,
 			Expected: &Predicate{
-				Name: "right",
+				Name: sptr("right"),
 				IDs: []*Atom{
 					{String: sptr("/a/file1.txt")},
-					{Variable: sptr("1")},
+					{Variable: varptr("1")},
 				},
 			},
 		},
 		{
 			Input: `right($1, "hex:41414141")`,
 			Expected: &Predicate{
-				Name: "right",
+				Name: sptr("right"),
 				IDs: []*Atom{
-					{Variable: sptr("1")},
+					{Variable: varptr("1")},
 					{Bytes: hexsptr("41414141")},
 				},
 			},
@@ -80,10 +80,10 @@ func TestGrammarPredicate(t *testing.T) {
 		{
 			Input: `right($1, ["hex:41414141", #sym])`,
 			Expected: &Predicate{
-				Name: "right",
+				Name: sptr("right"),
 				IDs: []*Atom{
-					{Variable: sptr("1")},
-					{Set: []*Atom{{Bytes: hexsptr("41414141")}, {Symbol: sptr("sym")}}},
+					{Variable: varptr("1")},
+					{Set: []*Atom{{Bytes: hexsptr("41414141")}, {Symbol: symptr("sym")}}},
 				},
 			},
 		},
@@ -111,7 +111,7 @@ func TestGrammarConstraint(t *testing.T) {
 			Input: `$0 == 1`,
 			Expected: &Constraint{
 				VariableConstraint: &VariableConstraint{
-					Variable: sptr("0"),
+					Variable: varptr("0"),
 					Int: &IntComparison{
 						Operation: sptr("=="),
 						Target:    i64ptr(1),
@@ -123,7 +123,7 @@ func TestGrammarConstraint(t *testing.T) {
 			Input: `$1 > 2`,
 			Expected: &Constraint{
 				VariableConstraint: &VariableConstraint{
-					Variable: sptr("1"),
+					Variable: varptr("1"),
 					Int: &IntComparison{
 						Operation: sptr(">"),
 						Target:    i64ptr(2),
@@ -135,7 +135,7 @@ func TestGrammarConstraint(t *testing.T) {
 			Input: `$0 >= 1`,
 			Expected: &Constraint{
 				VariableConstraint: &VariableConstraint{
-					Variable: sptr("0"),
+					Variable: varptr("0"),
 					Int: &IntComparison{
 						Operation: sptr(">="),
 						Target:    i64ptr(1),
@@ -147,7 +147,7 @@ func TestGrammarConstraint(t *testing.T) {
 			Input: `$0 < 1`,
 			Expected: &Constraint{
 				VariableConstraint: &VariableConstraint{
-					Variable: sptr("0"),
+					Variable: varptr("0"),
 					Int: &IntComparison{
 						Operation: sptr("<"),
 						Target:    i64ptr(1),
@@ -159,7 +159,7 @@ func TestGrammarConstraint(t *testing.T) {
 			Input: `$0 <= 1`,
 			Expected: &Constraint{
 				VariableConstraint: &VariableConstraint{
-					Variable: sptr("0"),
+					Variable: varptr("0"),
 					Int: &IntComparison{
 						Operation: sptr("<="),
 						Target:    i64ptr(1),
@@ -171,7 +171,7 @@ func TestGrammarConstraint(t *testing.T) {
 			Input: `$0 in [1, 2, 3]`,
 			Expected: &Constraint{
 				VariableConstraint: &VariableConstraint{
-					Variable: sptr("0"),
+					Variable: varptr("0"),
 					Set: &Set{
 						Int: []int64{1, 2, 3},
 						Not: false,
@@ -183,7 +183,7 @@ func TestGrammarConstraint(t *testing.T) {
 			Input: `$0 not in [4,5,6]`,
 			Expected: &Constraint{
 				VariableConstraint: &VariableConstraint{
-					Variable: sptr("0"),
+					Variable: varptr("0"),
 					Set: &Set{
 						Int: []int64{4, 5, 6},
 						Not: true,
@@ -195,7 +195,7 @@ func TestGrammarConstraint(t *testing.T) {
 			Input: `$0 == "abc"`,
 			Expected: &Constraint{
 				VariableConstraint: &VariableConstraint{
-					Variable: sptr("0"),
+					Variable: varptr("0"),
 					String: &StringComparison{
 						Operation: sptr("=="),
 						Target:    sptr("abc"),
@@ -208,7 +208,7 @@ func TestGrammarConstraint(t *testing.T) {
 			Expected: &Constraint{
 				FunctionConstraint: &FunctionConstraint{
 					Function: sptr("prefix"),
-					Variable: sptr("0"),
+					Variable: varptr("0"),
 					Argument: sptr("abc"),
 				},
 			},
@@ -218,7 +218,7 @@ func TestGrammarConstraint(t *testing.T) {
 			Expected: &Constraint{
 				FunctionConstraint: &FunctionConstraint{
 					Function: sptr("suffix"),
-					Variable: sptr("0"),
+					Variable: varptr("0"),
 					Argument: sptr("abc"),
 				},
 			},
@@ -228,7 +228,7 @@ func TestGrammarConstraint(t *testing.T) {
 			Expected: &Constraint{
 				FunctionConstraint: &FunctionConstraint{
 					Function: sptr("match"),
-					Variable: sptr("0"),
+					Variable: varptr("0"),
 					Argument: sptr("^abc[a-z]+$"),
 				},
 			},
@@ -237,7 +237,7 @@ func TestGrammarConstraint(t *testing.T) {
 			Input: `$0 in ["abc", "def"]`,
 			Expected: &Constraint{
 				VariableConstraint: &VariableConstraint{
-					Variable: sptr("0"),
+					Variable: varptr("0"),
 					Set: &Set{
 						String: []string{"abc", "def"},
 						Not:    false,
@@ -249,7 +249,7 @@ func TestGrammarConstraint(t *testing.T) {
 			Input: `$0 not in ["abc", "def"]`,
 			Expected: &Constraint{
 				VariableConstraint: &VariableConstraint{
-					Variable: sptr("0"),
+					Variable: varptr("0"),
 					Set: &Set{
 						String: []string{"abc", "def"},
 						Not:    true,
@@ -261,7 +261,7 @@ func TestGrammarConstraint(t *testing.T) {
 			Input: `$0 < "2006-01-02T15:04:05Z07:00"`,
 			Expected: &Constraint{
 				VariableConstraint: &VariableConstraint{
-					Variable: sptr("0"),
+					Variable: varptr("0"),
 					Date: &DateComparison{
 						Operation: sptr("<"),
 						Target:    sptr("2006-01-02T15:04:05Z07:00"),
@@ -273,7 +273,7 @@ func TestGrammarConstraint(t *testing.T) {
 			Input: `$0 > "2006-01-02T15:04:05Z07:00"`,
 			Expected: &Constraint{
 				VariableConstraint: &VariableConstraint{
-					Variable: sptr("0"),
+					Variable: varptr("0"),
 					Date: &DateComparison{
 						Operation: sptr(">"),
 						Target:    sptr("2006-01-02T15:04:05Z07:00"),
@@ -285,9 +285,9 @@ func TestGrammarConstraint(t *testing.T) {
 			Input: `$0 in [#a, #b, #c]`,
 			Expected: &Constraint{
 				VariableConstraint: &VariableConstraint{
-					Variable: sptr("0"),
+					Variable: varptr("0"),
 					Set: &Set{
-						Symbols: []string{"a", "b", "c"},
+						Symbols: []Symbol{"a", "b", "c"},
 						Not:     false,
 					},
 				},
@@ -297,9 +297,9 @@ func TestGrammarConstraint(t *testing.T) {
 			Input: `$0 not in [#a, #b, #c]`,
 			Expected: &Constraint{
 				VariableConstraint: &VariableConstraint{
-					Variable: sptr("0"),
+					Variable: varptr("0"),
 					Set: &Set{
-						Symbols: []string{"a", "b", "c"},
+						Symbols: []Symbol{"a", "b", "c"},
 						Not:     true,
 					},
 				},
@@ -309,7 +309,7 @@ func TestGrammarConstraint(t *testing.T) {
 			Input: `$0 in ["hex:41", "hex:42", "hex:43"]`,
 			Expected: &Constraint{
 				VariableConstraint: &VariableConstraint{
-					Variable: sptr("0"),
+					Variable: varptr("0"),
 					Set: &Set{
 						Bytes: []HexString{"41", "42", "43"},
 						Not:   false,
@@ -321,7 +321,7 @@ func TestGrammarConstraint(t *testing.T) {
 			Input: `$0 not in ["hex:abcdef", "hex:01234", "hex:56789"]`,
 			Expected: &Constraint{
 				VariableConstraint: &VariableConstraint{
-					Variable: sptr("0"),
+					Variable: varptr("0"),
 					Set: &Set{
 						Bytes: []HexString{"abcdef", "01234", "56789"},
 						Not:   true,
@@ -355,25 +355,25 @@ func TestGrammarCaveat(t *testing.T) {
 			Expected: &Caveat{[]*Rule{
 				{
 					Head: &Predicate{
-						Name: "grandparent",
+						Name: sptr("grandparent"),
 						IDs: []*Atom{
-							{Symbol: sptr("a")},
-							{Symbol: sptr("c")},
+							{Symbol: symptr("a")},
+							{Symbol: symptr("c")},
 						},
 					},
 					Body: []*Predicate{
 						{
-							Name: "parent",
+							Name: sptr("parent"),
 							IDs: []*Atom{
-								{Symbol: sptr("a")},
-								{Symbol: sptr("b")},
+								{Symbol: symptr("a")},
+								{Symbol: symptr("b")},
 							},
 						},
 						{
-							Name: "parent",
+							Name: sptr("parent"),
 							IDs: []*Atom{
-								{Symbol: sptr("b")},
-								{Symbol: sptr("c")},
+								{Symbol: symptr("b")},
+								{Symbol: symptr("c")},
 							},
 						},
 					},
@@ -385,57 +385,57 @@ func TestGrammarCaveat(t *testing.T) {
 			Expected: &Caveat{[]*Rule{
 				{
 					Head: &Predicate{
-						Name: "grandparent",
+						Name: sptr("grandparent"),
 						IDs: []*Atom{
-							{Symbol: sptr("a")},
-							{Symbol: sptr("c")},
+							{Symbol: symptr("a")},
+							{Symbol: symptr("c")},
 						},
 					},
 					Body: []*Predicate{
 						{
-							Name: "parent",
+							Name: sptr("parent"),
 							IDs: []*Atom{
-								{Symbol: sptr("a")},
-								{Symbol: sptr("b")},
+								{Symbol: symptr("a")},
+								{Symbol: symptr("b")},
 							},
 						},
 						{
-							Name: "parent",
+							Name: sptr("parent"),
 							IDs: []*Atom{
-								{Symbol: sptr("b")},
-								{Symbol: sptr("c")},
+								{Symbol: symptr("b")},
+								{Symbol: symptr("c")},
 							},
 						},
 					},
 				},
 				{
 					Head: &Predicate{
-						Name: "grandparent",
+						Name: sptr("grandparent"),
 						IDs: []*Atom{
-							{Symbol: sptr("a")},
-							{Symbol: sptr("c")},
+							{Symbol: symptr("a")},
+							{Symbol: symptr("c")},
 						},
 					},
 					Body: []*Predicate{
 						{
-							Name: "parent",
+							Name: sptr("parent"),
 							IDs: []*Atom{
-								{Symbol: sptr("a")},
-								{Symbol: sptr("b")},
+								{Symbol: symptr("a")},
+								{Symbol: symptr("b")},
 							},
 						},
 						{
-							Name: "parent",
+							Name: sptr("parent"),
 							IDs: []*Atom{
-								{Symbol: sptr("b")},
-								{Symbol: sptr("c")},
+								{Symbol: symptr("b")},
+								{Symbol: symptr("c")},
 							},
 						},
 					},
 					Constraints: []*Constraint{
 						{
 							VariableConstraint: &VariableConstraint{
-								Variable: sptr("0"),
+								Variable: varptr("0"),
 								Int: &IntComparison{
 									Operation: sptr(">"),
 									Target:    i64ptr(42),
@@ -445,7 +445,7 @@ func TestGrammarCaveat(t *testing.T) {
 						{
 							FunctionConstraint: &FunctionConstraint{
 								Function: sptr("prefix"),
-								Variable: sptr("1"),
+								Variable: varptr("1"),
 								Argument: sptr("test"),
 							},
 						},
@@ -477,25 +477,25 @@ func TestGrammarRule(t *testing.T) {
 			Input: `*grandparent(#a, #c) <- parent(#a, #b), parent(#b, #c)`,
 			Expected: &Rule{
 				Head: &Predicate{
-					Name: "grandparent",
+					Name: sptr("grandparent"),
 					IDs: []*Atom{
-						{Symbol: sptr("a")},
-						{Symbol: sptr("c")},
+						{Symbol: symptr("a")},
+						{Symbol: symptr("c")},
 					},
 				},
 				Body: []*Predicate{
 					{
-						Name: "parent",
+						Name: sptr("parent"),
 						IDs: []*Atom{
-							{Symbol: sptr("a")},
-							{Symbol: sptr("b")},
+							{Symbol: symptr("a")},
+							{Symbol: symptr("b")},
 						},
 					},
 					{
-						Name: "parent",
+						Name: sptr("parent"),
 						IDs: []*Atom{
-							{Symbol: sptr("b")},
-							{Symbol: sptr("c")},
+							{Symbol: symptr("b")},
+							{Symbol: symptr("c")},
 						},
 					},
 				},
@@ -505,32 +505,32 @@ func TestGrammarRule(t *testing.T) {
 			Input: `*grandparent(#a, #c) <- parent(#a, #b), parent(#b, #c) @ $0 > 42, prefix($1, "test")`,
 			Expected: &Rule{
 				Head: &Predicate{
-					Name: "grandparent",
+					Name: sptr("grandparent"),
 					IDs: []*Atom{
-						{Symbol: sptr("a")},
-						{Symbol: sptr("c")},
+						{Symbol: symptr("a")},
+						{Symbol: symptr("c")},
 					},
 				},
 				Body: []*Predicate{
 					{
-						Name: "parent",
+						Name: sptr("parent"),
 						IDs: []*Atom{
-							{Symbol: sptr("a")},
-							{Symbol: sptr("b")},
+							{Symbol: symptr("a")},
+							{Symbol: symptr("b")},
 						},
 					},
 					{
-						Name: "parent",
+						Name: sptr("parent"),
 						IDs: []*Atom{
-							{Symbol: sptr("b")},
-							{Symbol: sptr("c")},
+							{Symbol: symptr("b")},
+							{Symbol: symptr("c")},
 						},
 					},
 				},
 				Constraints: []*Constraint{
 					{
 						VariableConstraint: &VariableConstraint{
-							Variable: sptr("0"),
+							Variable: varptr("0"),
 							Int: &IntComparison{
 								Operation: sptr(">"),
 								Target:    i64ptr(42),
@@ -540,7 +540,7 @@ func TestGrammarRule(t *testing.T) {
 					{
 						FunctionConstraint: &FunctionConstraint{
 							Function: sptr("prefix"),
-							Variable: sptr("1"),
+							Variable: varptr("1"),
 							Argument: sptr("test"),
 						},
 					},
@@ -559,9 +559,20 @@ func TestGrammarRule(t *testing.T) {
 	}
 }
 
+func symptr(s string) *Symbol {
+	sym := Symbol(s)
+	return &sym
+}
+
+func varptr(s string) *Variable {
+	v := Variable(s)
+	return &v
+}
+
 func sptr(s string) *string {
 	return &s
 }
+
 func i64ptr(i int64) *int64 {
 	return &i
 }

--- a/parser/grammar_test.go
+++ b/parser/grammar_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestGrammarPredicate(t *testing.T) {
-	parser, err := participle.Build(&Predicate{}, defaultParserOptions...)
+	parser, err := participle.Build(&Predicate{}, DefaultParserOptions...)
 	require.NoError(t, err)
 
 	testCases := []struct {
@@ -100,7 +100,7 @@ func TestGrammarPredicate(t *testing.T) {
 }
 
 func TestGrammarConstraint(t *testing.T) {
-	parser, err := participle.Build(&Constraint{}, defaultParserOptions...)
+	parser, err := participle.Build(&Constraint{}, DefaultParserOptions...)
 	require.NoError(t, err)
 
 	testCases := []struct {
@@ -343,7 +343,7 @@ func TestGrammarConstraint(t *testing.T) {
 }
 
 func TestGrammarCaveat(t *testing.T) {
-	parser, err := participle.Build(&Caveat{}, defaultParserOptions...)
+	parser, err := participle.Build(&Caveat{}, DefaultParserOptions...)
 	require.NoError(t, err)
 
 	testCases := []struct {
@@ -466,7 +466,7 @@ func TestGrammarCaveat(t *testing.T) {
 }
 
 func TestGrammarRule(t *testing.T) {
-	parser, err := participle.Build(&Rule{}, defaultParserOptions...)
+	parser, err := participle.Build(&Rule{}, DefaultParserOptions...)
 	require.NoError(t, err)
 
 	testCases := []struct {

--- a/parser/grammar_test.go
+++ b/parser/grammar_test.go
@@ -474,8 +474,10 @@ func TestGrammarRule(t *testing.T) {
 		Expected *Rule
 	}{
 		{
-			Input: `*grandparent(#a, #c) <- parent(#a, #b), parent(#b, #c)`,
+			Input: `// some comment
+	*grandparent(#a, #c) <- parent(#a, #b), parent(#b, #c)`,
 			Expected: &Rule{
+				Comments: []*Comment{commentptr("some comment")},
 				Head: &Predicate{
 					Name: sptr("grandparent"),
 					IDs: []*Atom{
@@ -580,4 +582,9 @@ func i64ptr(i int64) *int64 {
 func hexsptr(s string) *HexString {
 	h := HexString(s)
 	return &h
+}
+
+func commentptr(s string) *Comment {
+	c := Comment(s)
+	return &c
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -13,7 +13,7 @@ var (
 	ErrVariableInSet  = errors.New("parser: a set cannot contain any variables")
 )
 
-var biscuitLexerRules = []stateful.Rule{
+var BiscuitLexerRules = []stateful.Rule{
 	{Name: "Keyword", Pattern: `rules|caveats`, Action: nil},
 	{Name: "Function", Pattern: `prefix|suffix|match`, Action: nil},
 	{Name: "Arrow", Pattern: `<-`, Action: nil},
@@ -30,8 +30,8 @@ var biscuitLexerRules = []stateful.Rule{
 	{Name: "Punct", Pattern: `[-[!@%^&#$*()+_={}\|:;"'<,>.?/]|]`, Action: nil},
 }
 
-var defaultParserOptions = []participle.Option{
-	participle.Lexer(stateful.MustSimple(biscuitLexerRules)),
+var DefaultParserOptions = []participle.Option{
+	participle.Lexer(stateful.MustSimple(BiscuitLexerRules)),
 	participle.UseLookahead(1),
 	participle.Elide("Whitespace", "EOL"),
 	participle.Unquote("String"),
@@ -66,9 +66,9 @@ var _ MustParser = (*mustParser)(nil)
 
 func New() Parser {
 	return &parser{
-		factParser:   participle.MustBuild(&Predicate{}, defaultParserOptions...),
-		ruleParser:   participle.MustBuild(&Rule{}, defaultParserOptions...),
-		caveatParser: participle.MustBuild(&Caveat{}, defaultParserOptions...),
+		factParser:   participle.MustBuild(&Predicate{}, DefaultParserOptions...),
+		ruleParser:   participle.MustBuild(&Rule{}, DefaultParserOptions...),
+		caveatParser: participle.MustBuild(&Caveat{}, DefaultParserOptions...),
 	}
 }
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 
 	"github.com/alecthomas/participle/v2"
-	"github.com/alecthomas/participle/v2/lexer"
+	"github.com/alecthomas/participle/v2/lexer/stateful"
 	"github.com/flynn/biscuit-go"
 )
 
@@ -13,9 +13,27 @@ var (
 	ErrVariableInSet  = errors.New("parser: a set cannot contain any variables")
 )
 
+var biscuitLexerRules = []stateful.Rule{
+	{Name: "Keyword", Pattern: `rules|caveats`, Action: nil},
+	{Name: "Function", Pattern: `prefix|suffix|match`, Action: nil},
+	{Name: "Arrow", Pattern: `<-`, Action: nil},
+	{Name: "Or", Pattern: `\|\|`, Action: nil},
+	{Name: "Operator", Pattern: `==|>=|<=|>|<|not|in`, Action: nil},
+	{Name: "Comment", Pattern: `//[^\n]*`, Action: nil},
+	{Name: "String", Pattern: `\"[^\"]*\"`, Action: nil},
+	{Name: "Variable", Pattern: `\$[a-zA-Z0-9_]+`, Action: nil},
+	{Name: "Int", Pattern: `[0-9]+`, Action: nil},
+	{Name: "Symbol", Pattern: `#[a-zA-Z0-9_]+`, Action: nil},
+	{Name: "Ident", Pattern: `[a-zA-Z0-9_]+`, Action: nil},
+	{Name: "Whitespace", Pattern: `[ \t]+`, Action: nil},
+	{Name: "EOL", Pattern: `[\n\r]+`, Action: nil},
+	{Name: "Punct", Pattern: `[-[!@%^&#$*()+_={}\|:;"'<,>.?/]|]`, Action: nil},
+}
+
 var defaultParserOptions = []participle.Option{
-	participle.Lexer(lexer.DefaultDefinition),
-	participle.UseLookahead(3),
+	participle.Lexer(stateful.MustSimple(biscuitLexerRules)),
+	participle.UseLookahead(1),
+	participle.Elide("Whitespace", "EOL"),
 	participle.Unquote("String"),
 }
 


### PR DESCRIPTION
This replace the default golang text scanner grammar by a full custom
one for more control over biscuit types and structures (ie: comments support).
The lexer will now rely on `biscuitLexerRules` instead of default golang text scanner.

- [x] This also require a fix from https://github.com/alecthomas/participle/pull/123