### PR TITLE
datalog: add world run limits

### DIFF
--- a/datalog/datalog.go
+++ b/datalog/datalog.go
@@ -2,7 +2,9 @@ package datalog
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"regexp"
 	"sort"
@@ -594,13 +596,62 @@ func (s *FactSet) Equal(x *FactSet) bool {
 	return true
 }
 
+type runLimits struct {
+	maxFacts      int
+	maxIterations int
+	maxDuration   time.Duration
+}
+
+var defaultRunLimits = runLimits{
+	maxFacts:      1000,
+	maxIterations: 100,
+	maxDuration:   1 * time.Millisecond,
+}
+
+var (
+	ErrWorldRunLimitMaxFacts      = errors.New("datalog: world runtime limit: too many facts")
+	ErrWorldRunLimitMaxIterations = errors.New("datalog: world runtime limit: too many iterations")
+	ErrWorldRunLimitTimeout       = errors.New("datalog: world runtime limit: timeout")
+)
+
+type WorldOption func(w *World)
+
+func WithMaxFacts(maxFacts int) WorldOption {
+	return func(w *World) {
+		w.runLimits.maxFacts = maxFacts
+	}
+}
+
+func WithMaxIterations(maxIterations int) WorldOption {
+	return func(w *World) {
+		w.runLimits.maxIterations = maxIterations
+	}
+}
+
+func WithMaxDuration(maxDuration time.Duration) WorldOption {
+	return func(w *World) {
+		w.runLimits.maxDuration = maxDuration
+	}
+}
+
 type World struct {
 	facts *FactSet
 	rules []Rule
+
+	runLimits runLimits
 }
 
-func NewWorld() *World {
-	return &World{facts: &FactSet{}}
+func NewWorld(opts ...WorldOption) *World {
+	w := &World{
+		facts:     &FactSet{},
+		runLimits: defaultRunLimits,
+	}
+
+	for _, opt := range opts {
+		opt(w)
+	}
+
+	return w
 }
 
 func (w *World) AddFact(f Fact) {
@@ -612,20 +663,54 @@ func (w *World) AddRule(r Rule) {
 }
 
 func (w *World) Run() error {
-	for i := 0; i < 100; i++ {
-		var newFacts FactSet
-		for _, r := range w.rules {
-			if err := r.Apply(w.facts, &newFacts); err != nil {
-				return err
+	done := make(chan error)
+	ctx, cancel := context.WithTimeout(context.Background(), w.runLimits.maxDuration)
+	defer cancel()
+
+	go func() {
+		for i := 0; i < w.runLimits.maxIterations; i++ {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				var newFacts FactSet
+				for _, r := range w.rules {
+					select {
+					case <-ctx.Done():
+						return
+					default:
+						if err := r.Apply(w.facts, &newFacts); err != nil {
+							done <- err
+							return
+						}
+					}
+				}
+
+				prevCount := len(*w.facts)
+				w.facts.InsertAll([]Fact(newFacts))
+
+				newCount := len(*w.facts)
+				if newCount >= w.runLimits.maxFacts {
+					done <- ErrWorldRunLimitMaxFacts
+					return
+				}
+
+				// last iteration did not generate any new facts, so we can stop here
+				if newCount == prevCount {
+					done <- nil
+					return
+				}
 			}
 		}
-		l := len(*w.facts)
-		w.facts.InsertAll([]Fact(newFacts))
-		if len(*w.facts) == l {
-			return nil
-		}
+		done <- ErrWorldRunLimitMaxIterations
+	}()
+
+	select {
+	case <-ctx.Done():
+		return ErrWorldRunLimitTimeout
+	case err := <-done:
+		return err
 	}
-	return fmt.Errorf("datalog: world ran more than 100 iterations")
 }
 
 func (w *World) Query(pred Predicate) *FactSet {
@@ -664,8 +749,9 @@ func (w *World) Clone() *World {
 	newFacts := new(FactSet)
 	*newFacts = *w.facts
 	return &World{
-		facts: newFacts,
-		rules: append([]Rule{}, w.rules...),
+		facts:     newFacts,
+		rules:     append([]Rule{}, w.rules...),
+		runLimits: w.runLimits,
 	}
 }
 


### PR DESCRIPTION
introduce run limits to the datalog world,
allowing to stop the execution when the processing
 - takes too long
 - generates too many facts
 - exceeds the iteration limit

fix #42