### PR TITLE
bump block version to 1

### DIFF
--- a/converters.go
+++ b/converters.go
@@ -1,0 +1,178 @@
+package biscuit
+
+import (
+	"fmt"
+
+	"github.com/flynn/biscuit-go/datalog"
+	"github.com/flynn/biscuit-go/pb"
+	"github.com/flynn/biscuit-go/sig"
+)
+
+func tokenBlockToProtoBlock(input *Block) (*pb.Block, error) {
+	out := &pb.Block{
+		Index:   input.index,
+		Symbols: *input.symbols,
+		Context: input.context,
+		Version: input.version,
+	}
+
+	switch input.version {
+	case 0:
+		out.FactsV0 = make([]*pb.FactV0, len(*input.facts))
+		var err error
+		for i, fact := range *input.facts {
+			out.FactsV0[i], err = tokenFactToProtoFactV0(fact)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		out.RulesV0 = make([]*pb.RuleV0, len(input.rules))
+		for i, rule := range input.rules {
+			r, err := tokenRuleToProtoRuleV0(rule)
+			if err != nil {
+				return nil, err
+			}
+			out.RulesV0[i] = r
+		}
+
+		out.CaveatsV0 = make([]*pb.CaveatV0, len(input.caveats))
+		for i, caveat := range input.caveats {
+			c, err := tokenCaveatToProtoCaveatV0(caveat)
+			if err != nil {
+				return nil, err
+			}
+			out.CaveatsV0[i] = c
+		}
+	case 1:
+		out.FactsV1 = make([]*pb.FactV1, len(*input.facts))
+		var err error
+		for i, fact := range *input.facts {
+			out.FactsV1[i], err = tokenFactToProtoFactV1(fact)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		out.RulesV1 = make([]*pb.RuleV1, len(input.rules))
+		for i, rule := range input.rules {
+			r, err := tokenRuleToProtoRuleV1(rule)
+			if err != nil {
+				return nil, err
+			}
+			out.RulesV1[i] = r
+		}
+
+		out.CaveatsV1 = make([]*pb.CaveatV1, len(input.caveats))
+		for i, caveat := range input.caveats {
+			c, err := tokenCaveatToProtoCaveatV1(caveat)
+			if err != nil {
+				return nil, err
+			}
+			out.CaveatsV1[i] = c
+		}
+	default:
+		return nil, fmt.Errorf("biscuit: failed to convert block to proto block: unsupported version %d", input.version)
+	}
+
+	return out, nil
+}
+
+func protoBlockToTokenBlock(input *pb.Block) (*Block, error) {
+	symbols := datalog.SymbolTable(input.Symbols)
+
+	var facts datalog.FactSet
+	var rules []datalog.Rule
+	var caveats []datalog.Caveat
+
+	if input.Version > MaxSchemaVersion {
+		return nil, fmt.Errorf(
+			"biscuit: failed to convert proto block to token block: block version: %d > library version %d",
+			input.Version,
+			MaxSchemaVersion,
+		)
+	}
+
+	switch input.Version {
+	case 0:
+		facts = make(datalog.FactSet, len(input.FactsV0))
+		rules = make([]datalog.Rule, len(input.RulesV0))
+		caveats = make([]datalog.Caveat, len(input.CaveatsV0))
+
+		for i, pbFact := range input.FactsV0 {
+			f, err := protoFactToTokenFactV0(pbFact)
+			if err != nil {
+				return nil, err
+			}
+			facts[i] = *f
+		}
+
+		for i, pbRule := range input.RulesV0 {
+			r, err := protoRuleToTokenRuleV0(pbRule)
+			if err != nil {
+				return nil, err
+			}
+			rules[i] = *r
+		}
+
+		for i, pbCaveat := range input.CaveatsV0 {
+			c, err := protoCaveatToTokenCaveatV0(pbCaveat)
+			if err != nil {
+				return nil, err
+			}
+			caveats[i] = *c
+		}
+	case 1:
+		facts = make(datalog.FactSet, len(input.FactsV1))
+		rules = make([]datalog.Rule, len(input.RulesV1))
+		caveats = make([]datalog.Caveat, len(input.CaveatsV1))
+
+		for i, pbFact := range input.FactsV1 {
+			f, err := protoFactToTokenFactV1(pbFact)
+			if err != nil {
+				return nil, err
+			}
+			facts[i] = *f
+		}
+
+		for i, pbRule := range input.RulesV1 {
+			r, err := protoRuleToTokenRuleV1(pbRule)
+			if err != nil {
+				return nil, err
+			}
+			rules[i] = *r
+		}
+
+		for i, pbCaveat := range input.CaveatsV1 {
+			c, err := protoCaveatToTokenCaveatV1(pbCaveat)
+			if err != nil {
+				return nil, err
+			}
+			caveats[i] = *c
+		}
+	default:
+		return nil, fmt.Errorf("biscuit: failed to convert proto block to token block: unsupported version: %d", input.Version)
+	}
+
+	return &Block{
+		index:   input.Index,
+		symbols: &symbols,
+		facts:   &facts,
+		rules:   rules,
+		caveats: caveats,
+		context: input.Context,
+		version: input.Version,
+	}, nil
+}
+
+func tokenSignatureToProtoSignature(ts *sig.TokenSignature) *pb.Signature {
+	params, z := ts.Encode()
+	return &pb.Signature{
+		Parameters: params,
+		Z:          z,
+	}
+}
+
+func protoSignatureToTokenSignature(ps *pb.Signature) (*sig.TokenSignature, error) {
+	return sig.Decode(ps.Parameters, ps.Z)
+}

--- a/converters_v0.go
+++ b/converters_v0.go
@@ -7,106 +7,21 @@ import (
 
 	"github.com/flynn/biscuit-go/datalog"
 	"github.com/flynn/biscuit-go/pb"
-	"github.com/flynn/biscuit-go/sig"
 )
 
-func tokenBlockToProtoBlock(input *Block) (*pb.Block, error) {
-	pbFacts := make([]*pb.Fact, len(*input.facts))
-	var err error
-	for i, fact := range *input.facts {
-		pbFacts[i], err = tokenFactToProtoFact(fact)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	pbRules := make([]*pb.Rule, len(input.rules))
-	for i, rule := range input.rules {
-		r, err := tokenRuleToProtoRule(rule)
-		if err != nil {
-			return nil, err
-		}
-		pbRules[i] = r
-	}
-
-	pbCaveats := make([]*pb.Caveat, len(input.caveats))
-	for i, caveat := range input.caveats {
-		c, err := tokenCaveatToProtoCaveat(caveat)
-		if err != nil {
-			return nil, err
-		}
-		pbCaveats[i] = c
-	}
-
-	return &pb.Block{
-		Index:   input.index,
-		Symbols: *input.symbols,
-		Facts:   pbFacts,
-		Rules:   pbRules,
-		Caveats: pbCaveats,
-		Context: input.context,
-		Version: input.version,
-	}, nil
-}
-
-func protoBlockToTokenBlock(input *pb.Block) (*Block, error) {
-	symbols := datalog.SymbolTable(input.Symbols)
-
-	facts := make(datalog.FactSet, len(input.Facts))
-	for i, pbFact := range input.Facts {
-		f, err := protoFactToTokenFact(pbFact)
-		if err != nil {
-			return nil, err
-		}
-		facts[i] = *f
-	}
-
-	rules := make([]datalog.Rule, len(input.Rules))
-	for i, pbRule := range input.Rules {
-		r, err := protoRuleToTokenRule(pbRule)
-		if err != nil {
-			return nil, err
-		}
-		rules[i] = *r
-	}
-
-	caveats := make([]datalog.Caveat, len(input.Caveats))
-	for i, pbCaveat := range input.Caveats {
-		c, err := protoCaveatToTokenCaveat(pbCaveat)
-		if err != nil {
-			return nil, err
-		}
-		caveats[i] = *c
-	}
-
-	if input.Version > MaxSchemaVersion {
-		return nil, fmt.Errorf("biscuit: unsupported block version: %d", input.Version)
-	}
-
-	return &Block{
-		index:   input.Index,
-		symbols: &symbols,
-		facts:   &facts,
-		rules:   rules,
-		caveats: caveats,
-		context: input.Context,
-		version: input.Version,
-	}, nil
-}
-
-func tokenFactToProtoFact(input datalog.Fact) (*pb.Fact, error) {
-	pred, err := tokenPredicateToProtoPredicate(input.Predicate)
+func tokenFactToProtoFactV0(input datalog.Fact) (*pb.FactV0, error) {
+	pred, err := tokenPredicateToProtoPredicateV0(input.Predicate)
 	if err != nil {
 		return nil, err
 	}
 
-	return &pb.Fact{
+	return &pb.FactV0{
 		Predicate: pred,
 	}, nil
 }
 
-func protoFactToTokenFact(input *pb.Fact) (*datalog.Fact, error) {
-	pred, err := protoPredicateToTokenPredicate(input.Predicate)
+func protoFactToTokenFactV0(input *pb.FactV0) (*datalog.Fact, error) {
+	pred, err := protoPredicateToTokenPredicateV0(input.Predicate)
 	if err != nil {
 		return nil, err
 	}
@@ -115,26 +30,26 @@ func protoFactToTokenFact(input *pb.Fact) (*datalog.Fact, error) {
 	}, nil
 }
 
-func tokenPredicateToProtoPredicate(input datalog.Predicate) (*pb.Predicate, error) {
-	pbIds := make([]*pb.ID, len(input.IDs))
+func tokenPredicateToProtoPredicateV0(input datalog.Predicate) (*pb.PredicateV0, error) {
+	pbIds := make([]*pb.IDV0, len(input.IDs))
 	var err error
 	for i, id := range input.IDs {
-		pbIds[i], err = tokenIDToProtoID(id)
+		pbIds[i], err = tokenIDToProtoIDV0(id)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	return &pb.Predicate{
+	return &pb.PredicateV0{
 		Name: uint64(input.Name),
 		Ids:  pbIds,
 	}, nil
 }
 
-func protoPredicateToTokenPredicate(input *pb.Predicate) (*datalog.Predicate, error) {
+func protoPredicateToTokenPredicateV0(input *pb.PredicateV0) (*datalog.Predicate, error) {
 	ids := make([]datalog.ID, len(input.Ids))
 	for i, id := range input.Ids {
-		dlid, err := protoIDToTokenID(id)
+		dlid, err := protoIDToTokenIDV0(id)
 		if err != nil {
 			return nil, err
 		}
@@ -148,51 +63,51 @@ func protoPredicateToTokenPredicate(input *pb.Predicate) (*datalog.Predicate, er
 	}, nil
 }
 
-func tokenIDToProtoID(input datalog.ID) (*pb.ID, error) {
-	var pbId *pb.ID
+func tokenIDToProtoIDV0(input datalog.ID) (*pb.IDV0, error) {
+	var pbId *pb.IDV0
 	switch input.Type() {
 	case datalog.IDTypeString:
-		pbId = &pb.ID{
-			Kind: pb.ID_STR,
+		pbId = &pb.IDV0{
+			Kind: pb.IDV0_STR,
 			Str:  string(input.(datalog.String)),
 		}
 	case datalog.IDTypeDate:
-		pbId = &pb.ID{
-			Kind: pb.ID_DATE,
+		pbId = &pb.IDV0{
+			Kind: pb.IDV0_DATE,
 			Date: uint64(input.(datalog.Date)),
 		}
 	case datalog.IDTypeInteger:
-		pbId = &pb.ID{
-			Kind:    pb.ID_INTEGER,
+		pbId = &pb.IDV0{
+			Kind:    pb.IDV0_INTEGER,
 			Integer: int64(input.(datalog.Integer)),
 		}
 	case datalog.IDTypeSymbol:
-		pbId = &pb.ID{
-			Kind:   pb.ID_SYMBOL,
+		pbId = &pb.IDV0{
+			Kind:   pb.IDV0_SYMBOL,
 			Symbol: uint64(input.(datalog.Symbol)),
 		}
 	case datalog.IDTypeVariable:
-		pbId = &pb.ID{
-			Kind:     pb.ID_VARIABLE,
+		pbId = &pb.IDV0{
+			Kind:     pb.IDV0_VARIABLE,
 			Variable: uint32(input.(datalog.Variable)),
 		}
 	case datalog.IDTypeBytes:
-		pbId = &pb.ID{
-			Kind:  pb.ID_BYTES,
+		pbId = &pb.IDV0{
+			Kind:  pb.IDV0_BYTES,
 			Bytes: input.(datalog.Bytes),
 		}
 	case datalog.IDTypeSet:
 		datalogSet := input.(datalog.Set)
-		protoSet := make([]*pb.ID, 0, len(datalogSet))
+		protoSet := make([]*pb.IDV0, 0, len(datalogSet))
 		for _, datalogElt := range datalogSet {
-			protoElt, err := tokenIDToProtoID(datalogElt)
+			protoElt, err := tokenIDToProtoIDV0(datalogElt)
 			if err != nil {
 				return nil, err
 			}
 			protoSet = append(protoSet, protoElt)
 		}
-		pbId = &pb.ID{
-			Kind: pb.ID_SET,
+		pbId = &pb.IDV0{
+			Kind: pb.IDV0_SET,
 			Set:  protoSet,
 		}
 	default:
@@ -201,25 +116,25 @@ func tokenIDToProtoID(input datalog.ID) (*pb.ID, error) {
 	return pbId, nil
 }
 
-func protoIDToTokenID(input *pb.ID) (*datalog.ID, error) {
+func protoIDToTokenIDV0(input *pb.IDV0) (*datalog.ID, error) {
 	var id datalog.ID
 	switch input.Kind {
-	case pb.ID_STR:
+	case pb.IDV0_STR:
 		id = datalog.String(input.Str)
-	case pb.ID_DATE:
+	case pb.IDV0_DATE:
 		id = datalog.Date(input.Date)
-	case pb.ID_INTEGER:
+	case pb.IDV0_INTEGER:
 		id = datalog.Integer(input.Integer)
-	case pb.ID_SYMBOL:
+	case pb.IDV0_SYMBOL:
 		id = datalog.Symbol(input.Symbol)
-	case pb.ID_VARIABLE:
+	case pb.IDV0_VARIABLE:
 		id = datalog.Variable(input.Variable)
-	case pb.ID_BYTES:
+	case pb.IDV0_BYTES:
 		id = datalog.Bytes(input.Bytes)
-	case pb.ID_SET:
+	case pb.IDV0_SET:
 		datalogSet := make(datalog.Set, 0, len(input.Set))
 		for _, protoElt := range input.Set {
-			datalogElt, err := protoIDToTokenID(protoElt)
+			datalogElt, err := protoIDToTokenIDV0(protoElt)
 			if err != nil {
 				return nil, err
 			}
@@ -233,41 +148,41 @@ func protoIDToTokenID(input *pb.ID) (*datalog.ID, error) {
 	return &id, nil
 }
 
-func tokenRuleToProtoRule(input datalog.Rule) (*pb.Rule, error) {
-	pbBody := make([]*pb.Predicate, len(input.Body))
+func tokenRuleToProtoRuleV0(input datalog.Rule) (*pb.RuleV0, error) {
+	pbBody := make([]*pb.PredicateV0, len(input.Body))
 	for i, p := range input.Body {
-		pred, err := tokenPredicateToProtoPredicate(p)
+		pred, err := tokenPredicateToProtoPredicateV0(p)
 		if err != nil {
 			return nil, err
 		}
 		pbBody[i] = pred
 	}
 
-	pbConstraints := make([]*pb.Constraint, len(input.Constraints))
+	pbConstraints := make([]*pb.ConstraintV0, len(input.Constraints))
 	for i, c := range input.Constraints {
-		cons, err := tokenConstraintToProtoConstraint(c)
+		cons, err := tokenConstraintToProtoConstraintV0(c)
 		if err != nil {
 			return nil, err
 		}
 		pbConstraints[i] = cons
 	}
 
-	pbHead, err := tokenPredicateToProtoPredicate(input.Head)
+	pbHead, err := tokenPredicateToProtoPredicateV0(input.Head)
 	if err != nil {
 		return nil, err
 	}
 
-	return &pb.Rule{
+	return &pb.RuleV0{
 		Head:        pbHead,
 		Body:        pbBody,
 		Constraints: pbConstraints,
 	}, nil
 }
 
-func protoRuleToTokenRule(input *pb.Rule) (*datalog.Rule, error) {
+func protoRuleToTokenRuleV0(input *pb.RuleV0) (*datalog.Rule, error) {
 	body := make([]datalog.Predicate, len(input.Body))
 	for i, pb := range input.Body {
-		b, err := protoPredicateToTokenPredicate(pb)
+		b, err := protoPredicateToTokenPredicateV0(pb)
 		if err != nil {
 			return nil, err
 		}
@@ -276,14 +191,14 @@ func protoRuleToTokenRule(input *pb.Rule) (*datalog.Rule, error) {
 
 	constraints := make([]datalog.Constraint, len(input.Constraints))
 	for i, pbConstraint := range input.Constraints {
-		c, err := protoConstraintToTokenConstraint(pbConstraint)
+		c, err := protoConstraintToTokenConstraintV0(pbConstraint)
 		if err != nil {
 			return nil, err
 		}
 		constraints[i] = *c
 	}
 
-	head, err := protoPredicateToTokenPredicate(input.Head)
+	head, err := protoPredicateToTokenPredicateV0(input.Head)
 	if err != nil {
 		return nil, err
 	}
@@ -294,84 +209,84 @@ func protoRuleToTokenRule(input *pb.Rule) (*datalog.Rule, error) {
 	}, nil
 }
 
-func tokenConstraintToProtoConstraint(input datalog.Constraint) (*pb.Constraint, error) {
-	var pbConstraint *pb.Constraint
+func tokenConstraintToProtoConstraintV0(input datalog.Constraint) (*pb.ConstraintV0, error) {
+	var pbConstraint *pb.ConstraintV0
 	switch input.Checker.(type) {
 	case datalog.DateComparisonChecker:
-		c, err := tokenDateConstraintToProtoDateConstraint(input.Checker.(datalog.DateComparisonChecker))
+		c, err := tokenDateConstraintToProtoDateConstraintV0(input.Checker.(datalog.DateComparisonChecker))
 		if err != nil {
 			return nil, err
 		}
-		pbConstraint = &pb.Constraint{
+		pbConstraint = &pb.ConstraintV0{
 			Id:   uint32(input.Name),
-			Kind: pb.Constraint_DATE,
+			Kind: pb.ConstraintV0_DATE,
 			Date: c,
 		}
 	case datalog.IntegerComparisonChecker:
-		c, err := tokenIntConstraintToProtoIntConstraint(input.Checker.(datalog.IntegerComparisonChecker))
+		c, err := tokenIntConstraintToProtoIntConstraintV0(input.Checker.(datalog.IntegerComparisonChecker))
 		if err != nil {
 			return nil, err
 		}
-		pbConstraint = &pb.Constraint{
+		pbConstraint = &pb.ConstraintV0{
 			Id:   uint32(input.Name),
-			Kind: pb.Constraint_INT,
+			Kind: pb.ConstraintV0_INT,
 			Int:  c,
 		}
 	case datalog.IntegerInChecker:
-		pbConstraint = &pb.Constraint{
+		pbConstraint = &pb.ConstraintV0{
 			Id:   uint32(input.Name),
-			Kind: pb.Constraint_INT,
-			Int:  tokenIntInConstraintToProtoIntConstraint(input.Checker.(datalog.IntegerInChecker)),
+			Kind: pb.ConstraintV0_INT,
+			Int:  tokenIntInConstraintToProtoIntConstraintV0(input.Checker.(datalog.IntegerInChecker)),
 		}
 	case datalog.StringComparisonChecker:
-		c, err := tokenStrConstraintToProtoStrConstraint(input.Checker.(datalog.StringComparisonChecker))
+		c, err := tokenStrConstraintToProtoStrConstraintV0(input.Checker.(datalog.StringComparisonChecker))
 		if err != nil {
 			return nil, err
 		}
-		pbConstraint = &pb.Constraint{
+		pbConstraint = &pb.ConstraintV0{
 			Id:   uint32(input.Name),
-			Kind: pb.Constraint_STRING,
+			Kind: pb.ConstraintV0_STRING,
 			Str:  c,
 		}
 	case datalog.StringInChecker:
-		pbConstraint = &pb.Constraint{
+		pbConstraint = &pb.ConstraintV0{
 			Id:   uint32(input.Name),
-			Kind: pb.Constraint_STRING,
-			Str:  tokenStrInConstraintToProtoStrConstraint(input.Checker.(datalog.StringInChecker)),
+			Kind: pb.ConstraintV0_STRING,
+			Str:  tokenStrInConstraintToProtoStrConstraintV0(input.Checker.(datalog.StringInChecker)),
 		}
 	case *datalog.StringRegexpChecker:
-		pbConstraint = &pb.Constraint{
+		pbConstraint = &pb.ConstraintV0{
 			Id:   uint32(input.Name),
-			Kind: pb.Constraint_STRING,
-			Str: &pb.StringConstraint{
-				Kind:  pb.StringConstraint_REGEX,
+			Kind: pb.ConstraintV0_STRING,
+			Str: &pb.StringConstraintV0{
+				Kind:  pb.StringConstraintV0_REGEX,
 				Regex: (*regexp.Regexp)(input.Checker.(*datalog.StringRegexpChecker)).String(),
 			},
 		}
 	case datalog.SymbolInChecker:
-		pbConstraint = &pb.Constraint{
+		pbConstraint = &pb.ConstraintV0{
 			Id:     uint32(input.Name),
-			Kind:   pb.Constraint_SYMBOL,
-			Symbol: tokenSymbolConstraintToProtoSymbolConstraint(input.Checker.(datalog.SymbolInChecker)),
+			Kind:   pb.ConstraintV0_SYMBOL,
+			Symbol: tokenSymbolConstraintToProtoSymbolConstraintV0(input.Checker.(datalog.SymbolInChecker)),
 		}
 	case datalog.BytesComparisonChecker:
-		c, err := tokenBytesConstraintToProtoBytesConstraint(input.Checker.(datalog.BytesComparisonChecker))
+		c, err := tokenBytesConstraintToProtoBytesConstraintV0(input.Checker.(datalog.BytesComparisonChecker))
 		if err != nil {
 			return nil, err
 		}
-		pbConstraint = &pb.Constraint{
+		pbConstraint = &pb.ConstraintV0{
 			Id:    uint32(input.Name),
-			Kind:  pb.Constraint_BYTES,
+			Kind:  pb.ConstraintV0_BYTES,
 			Bytes: c,
 		}
 	case datalog.BytesInChecker:
-		c, err := tokenBytesInConstraintToProtoBytesConstraint(input.Checker.(datalog.BytesInChecker))
+		c, err := tokenBytesInConstraintToProtoBytesConstraintV0(input.Checker.(datalog.BytesInChecker))
 		if err != nil {
 			return nil, err
 		}
-		pbConstraint = &pb.Constraint{
+		pbConstraint = &pb.ConstraintV0{
 			Id:    uint32(input.Name),
-			Kind:  pb.Constraint_BYTES,
+			Kind:  pb.ConstraintV0_BYTES,
 			Bytes: c,
 		}
 	default:
@@ -381,11 +296,11 @@ func tokenConstraintToProtoConstraint(input datalog.Constraint) (*pb.Constraint,
 	return pbConstraint, nil
 }
 
-func protoConstraintToTokenConstraint(input *pb.Constraint) (*datalog.Constraint, error) {
+func protoConstraintToTokenConstraintV0(input *pb.ConstraintV0) (*datalog.Constraint, error) {
 	var constraint datalog.Constraint
 	switch input.Kind {
-	case pb.Constraint_DATE:
-		c, err := protoDateConstraintToTokenDateConstraint(input.Date)
+	case pb.ConstraintV0_DATE:
+		c, err := protoDateConstraintToTokenDateConstraintV0(input.Date)
 		if err != nil {
 			return nil, err
 		}
@@ -393,8 +308,8 @@ func protoConstraintToTokenConstraint(input *pb.Constraint) (*datalog.Constraint
 			Name:    datalog.Variable(input.Id),
 			Checker: *c,
 		}
-	case pb.Constraint_INT:
-		c, err := protoIntConstraintToTokenIntConstraint(input.Int)
+	case pb.ConstraintV0_INT:
+		c, err := protoIntConstraintToTokenIntConstraintV0(input.Int)
 		if err != nil {
 			return nil, err
 		}
@@ -402,8 +317,8 @@ func protoConstraintToTokenConstraint(input *pb.Constraint) (*datalog.Constraint
 			Name:    datalog.Variable(input.Id),
 			Checker: *c,
 		}
-	case pb.Constraint_STRING:
-		c, err := protoStrConstraintToTokenStrConstraint(input.Str)
+	case pb.ConstraintV0_STRING:
+		c, err := protoStrConstraintToTokenStrConstraintV0(input.Str)
 		if err != nil {
 			return nil, err
 		}
@@ -411,8 +326,8 @@ func protoConstraintToTokenConstraint(input *pb.Constraint) (*datalog.Constraint
 			Name:    datalog.Variable(input.Id),
 			Checker: *c,
 		}
-	case pb.Constraint_SYMBOL:
-		c, err := protoSymbolConstraintToTokenSymbolConstraint(input.Symbol)
+	case pb.ConstraintV0_SYMBOL:
+		c, err := protoSymbolConstraintToTokenSymbolConstraintV0(input.Symbol)
 		if err != nil {
 			return nil, err
 		}
@@ -420,8 +335,8 @@ func protoConstraintToTokenConstraint(input *pb.Constraint) (*datalog.Constraint
 			Name:    datalog.Variable(input.Id),
 			Checker: *c,
 		}
-	case pb.Constraint_BYTES:
-		c, err := protoBytesConstraintToTokenBytesConstraint(input.Bytes)
+	case pb.ConstraintV0_BYTES:
+		c, err := protoBytesConstraintToTokenBytesConstraintV0(input.Bytes)
 		if err != nil {
 			return nil, err
 		}
@@ -436,17 +351,17 @@ func protoConstraintToTokenConstraint(input *pb.Constraint) (*datalog.Constraint
 	return &constraint, nil
 }
 
-func tokenDateConstraintToProtoDateConstraint(input datalog.DateComparisonChecker) (*pb.DateConstraint, error) {
-	var pbDateConstraint *pb.DateConstraint
+func tokenDateConstraintToProtoDateConstraintV0(input datalog.DateComparisonChecker) (*pb.DateConstraintV0, error) {
+	var pbDateConstraint *pb.DateConstraintV0
 	switch input.Comparison {
 	case datalog.DateComparisonBefore:
-		pbDateConstraint = &pb.DateConstraint{
-			Kind:   pb.DateConstraint_BEFORE,
+		pbDateConstraint = &pb.DateConstraintV0{
+			Kind:   pb.DateConstraintV0_BEFORE,
 			Before: uint64(input.Date),
 		}
 	case datalog.DateComparisonAfter:
-		pbDateConstraint = &pb.DateConstraint{
-			Kind:  pb.DateConstraint_AFTER,
+		pbDateConstraint = &pb.DateConstraintV0{
+			Kind:  pb.DateConstraintV0_AFTER,
 			After: uint64(input.Date),
 		}
 	default:
@@ -456,15 +371,15 @@ func tokenDateConstraintToProtoDateConstraint(input datalog.DateComparisonChecke
 	return pbDateConstraint, nil
 }
 
-func protoDateConstraintToTokenDateConstraint(input *pb.DateConstraint) (*datalog.Checker, error) {
+func protoDateConstraintToTokenDateConstraintV0(input *pb.DateConstraintV0) (*datalog.Checker, error) {
 	var checker datalog.Checker
 	switch input.Kind {
-	case pb.DateConstraint_BEFORE:
+	case pb.DateConstraintV0_BEFORE:
 		checker = datalog.DateComparisonChecker{
 			Comparison: datalog.DateComparisonBefore,
 			Date:       datalog.Date(input.Before),
 		}
-	case pb.DateConstraint_AFTER:
+	case pb.DateConstraintV0_AFTER:
 		checker = datalog.DateComparisonChecker{
 			Comparison: datalog.DateComparisonAfter,
 			Date:       datalog.Date(input.After),
@@ -475,32 +390,32 @@ func protoDateConstraintToTokenDateConstraint(input *pb.DateConstraint) (*datalo
 	return &checker, nil
 }
 
-func tokenIntConstraintToProtoIntConstraint(input datalog.IntegerComparisonChecker) (*pb.IntConstraint, error) {
-	var pbIntConstraint *pb.IntConstraint
+func tokenIntConstraintToProtoIntConstraintV0(input datalog.IntegerComparisonChecker) (*pb.IntConstraintV0, error) {
+	var pbIntConstraint *pb.IntConstraintV0
 	switch input.Comparison {
 	case datalog.IntegerComparisonEqual:
-		pbIntConstraint = &pb.IntConstraint{
-			Kind:  pb.IntConstraint_EQUAL,
+		pbIntConstraint = &pb.IntConstraintV0{
+			Kind:  pb.IntConstraintV0_EQUAL,
 			Equal: int64(input.Integer),
 		}
 	case datalog.IntegerComparisonGT:
-		pbIntConstraint = &pb.IntConstraint{
-			Kind:   pb.IntConstraint_LARGER,
+		pbIntConstraint = &pb.IntConstraintV0{
+			Kind:   pb.IntConstraintV0_LARGER,
 			Larger: int64(input.Integer),
 		}
 	case datalog.IntegerComparisonGTE:
-		pbIntConstraint = &pb.IntConstraint{
-			Kind:          pb.IntConstraint_LARGER_OR_EQUAL,
+		pbIntConstraint = &pb.IntConstraintV0{
+			Kind:          pb.IntConstraintV0_LARGER_OR_EQUAL,
 			LargerOrEqual: int64(input.Integer),
 		}
 	case datalog.IntegerComparisonLT:
-		pbIntConstraint = &pb.IntConstraint{
-			Kind:  pb.IntConstraint_LOWER,
+		pbIntConstraint = &pb.IntConstraintV0{
+			Kind:  pb.IntConstraintV0_LOWER,
 			Lower: int64(input.Integer),
 		}
 	case datalog.IntegerComparisonLTE:
-		pbIntConstraint = &pb.IntConstraint{
-			Kind:         pb.IntConstraint_LOWER_OR_EQUAL,
+		pbIntConstraint = &pb.IntConstraintV0{
+			Kind:         pb.IntConstraintV0_LOWER_OR_EQUAL,
 			LowerOrEqual: int64(input.Integer),
 		}
 	default:
@@ -509,8 +424,8 @@ func tokenIntConstraintToProtoIntConstraint(input datalog.IntegerComparisonCheck
 	return pbIntConstraint, nil
 }
 
-func tokenIntInConstraintToProtoIntConstraint(input datalog.IntegerInChecker) *pb.IntConstraint {
-	var pbIntConstraint *pb.IntConstraint
+func tokenIntInConstraintToProtoIntConstraintV0(input datalog.IntegerInChecker) *pb.IntConstraintV0 {
+	var pbIntConstraint *pb.IntConstraintV0
 
 	pbSet := make([]int64, 0, len(input.Set))
 	for e := range input.Set {
@@ -518,28 +433,28 @@ func tokenIntInConstraintToProtoIntConstraint(input datalog.IntegerInChecker) *p
 	}
 
 	if input.Not {
-		pbIntConstraint = &pb.IntConstraint{
-			Kind:     pb.IntConstraint_NOT_IN,
+		pbIntConstraint = &pb.IntConstraintV0{
+			Kind:     pb.IntConstraintV0_NOT_IN,
 			NotInSet: pbSet,
 		}
 	} else {
-		pbIntConstraint = &pb.IntConstraint{
-			Kind:  pb.IntConstraint_IN,
+		pbIntConstraint = &pb.IntConstraintV0{
+			Kind:  pb.IntConstraintV0_IN,
 			InSet: pbSet,
 		}
 	}
 	return pbIntConstraint
 }
 
-func protoIntConstraintToTokenIntConstraint(input *pb.IntConstraint) (*datalog.Checker, error) {
+func protoIntConstraintToTokenIntConstraintV0(input *pb.IntConstraintV0) (*datalog.Checker, error) {
 	var checker datalog.Checker
 	switch input.Kind {
-	case pb.IntConstraint_EQUAL:
+	case pb.IntConstraintV0_EQUAL:
 		checker = datalog.IntegerComparisonChecker{
 			Comparison: datalog.IntegerComparisonEqual,
 			Integer:    datalog.Integer(input.Equal),
 		}
-	case pb.IntConstraint_IN:
+	case pb.IntConstraintV0_IN:
 		set := make(map[datalog.Integer]struct{}, len(input.InSet))
 		for _, i := range input.InSet {
 			set[datalog.Integer(i)] = struct{}{}
@@ -548,7 +463,7 @@ func protoIntConstraintToTokenIntConstraint(input *pb.IntConstraint) (*datalog.C
 			Set: set,
 			Not: false,
 		}
-	case pb.IntConstraint_NOT_IN:
+	case pb.IntConstraintV0_NOT_IN:
 		set := make(map[datalog.Integer]struct{}, len(input.NotInSet))
 		for _, i := range input.NotInSet {
 			set[datalog.Integer(i)] = struct{}{}
@@ -557,22 +472,22 @@ func protoIntConstraintToTokenIntConstraint(input *pb.IntConstraint) (*datalog.C
 			Set: set,
 			Not: true,
 		}
-	case pb.IntConstraint_LARGER:
+	case pb.IntConstraintV0_LARGER:
 		checker = datalog.IntegerComparisonChecker{
 			Comparison: datalog.IntegerComparisonGT,
 			Integer:    datalog.Integer(input.Larger),
 		}
-	case pb.IntConstraint_LARGER_OR_EQUAL:
+	case pb.IntConstraintV0_LARGER_OR_EQUAL:
 		checker = datalog.IntegerComparisonChecker{
 			Comparison: datalog.IntegerComparisonGTE,
 			Integer:    datalog.Integer(input.LargerOrEqual),
 		}
-	case pb.IntConstraint_LOWER:
+	case pb.IntConstraintV0_LOWER:
 		checker = datalog.IntegerComparisonChecker{
 			Comparison: datalog.IntegerComparisonLT,
 			Integer:    datalog.Integer(input.Lower),
 		}
-	case pb.IntConstraint_LOWER_OR_EQUAL:
+	case pb.IntConstraintV0_LOWER_OR_EQUAL:
 		checker = datalog.IntegerComparisonChecker{
 			Comparison: datalog.IntegerComparisonLTE,
 			Integer:    datalog.Integer(input.LowerOrEqual),
@@ -583,22 +498,22 @@ func protoIntConstraintToTokenIntConstraint(input *pb.IntConstraint) (*datalog.C
 	return &checker, nil
 }
 
-func tokenStrConstraintToProtoStrConstraint(input datalog.StringComparisonChecker) (*pb.StringConstraint, error) {
-	var pbStrConstraint *pb.StringConstraint
+func tokenStrConstraintToProtoStrConstraintV0(input datalog.StringComparisonChecker) (*pb.StringConstraintV0, error) {
+	var pbStrConstraint *pb.StringConstraintV0
 	switch input.Comparison {
 	case datalog.StringComparisonEqual:
-		pbStrConstraint = &pb.StringConstraint{
-			Kind:  pb.StringConstraint_EQUAL,
+		pbStrConstraint = &pb.StringConstraintV0{
+			Kind:  pb.StringConstraintV0_EQUAL,
 			Equal: string(input.Str),
 		}
 	case datalog.StringComparisonPrefix:
-		pbStrConstraint = &pb.StringConstraint{
-			Kind:   pb.StringConstraint_PREFIX,
+		pbStrConstraint = &pb.StringConstraintV0{
+			Kind:   pb.StringConstraintV0_PREFIX,
 			Prefix: string(input.Str),
 		}
 	case datalog.StringComparisonSuffix:
-		pbStrConstraint = &pb.StringConstraint{
-			Kind:   pb.StringConstraint_SUFFIX,
+		pbStrConstraint = &pb.StringConstraintV0{
+			Kind:   pb.StringConstraintV0_SUFFIX,
 			Suffix: string(input.Str),
 		}
 	default:
@@ -607,8 +522,8 @@ func tokenStrConstraintToProtoStrConstraint(input datalog.StringComparisonChecke
 	return pbStrConstraint, nil
 }
 
-func tokenStrInConstraintToProtoStrConstraint(input datalog.StringInChecker) *pb.StringConstraint {
-	var pbStringConstraint *pb.StringConstraint
+func tokenStrInConstraintToProtoStrConstraintV0(input datalog.StringInChecker) *pb.StringConstraintV0 {
+	var pbStringConstraint *pb.StringConstraintV0
 
 	pbSet := make([]string, 0, len(input.Set))
 	for e := range input.Set {
@@ -616,28 +531,28 @@ func tokenStrInConstraintToProtoStrConstraint(input datalog.StringInChecker) *pb
 	}
 
 	if input.Not {
-		pbStringConstraint = &pb.StringConstraint{
-			Kind:     pb.StringConstraint_NOT_IN,
+		pbStringConstraint = &pb.StringConstraintV0{
+			Kind:     pb.StringConstraintV0_NOT_IN,
 			NotInSet: pbSet,
 		}
 	} else {
-		pbStringConstraint = &pb.StringConstraint{
-			Kind:  pb.StringConstraint_IN,
+		pbStringConstraint = &pb.StringConstraintV0{
+			Kind:  pb.StringConstraintV0_IN,
 			InSet: pbSet,
 		}
 	}
 	return pbStringConstraint
 }
 
-func protoStrConstraintToTokenStrConstraint(input *pb.StringConstraint) (*datalog.Checker, error) {
+func protoStrConstraintToTokenStrConstraintV0(input *pb.StringConstraintV0) (*datalog.Checker, error) {
 	var checker datalog.Checker
 	switch input.Kind {
-	case pb.StringConstraint_EQUAL:
+	case pb.StringConstraintV0_EQUAL:
 		checker = datalog.StringComparisonChecker{
 			Comparison: datalog.StringComparisonEqual,
 			Str:        datalog.String(input.Equal),
 		}
-	case pb.StringConstraint_IN:
+	case pb.StringConstraintV0_IN:
 		set := make(map[datalog.String]struct{}, len(input.InSet))
 		for _, s := range input.InSet {
 			set[datalog.String(s)] = struct{}{}
@@ -646,7 +561,7 @@ func protoStrConstraintToTokenStrConstraint(input *pb.StringConstraint) (*datalo
 			Set: set,
 			Not: false,
 		}
-	case pb.StringConstraint_NOT_IN:
+	case pb.StringConstraintV0_NOT_IN:
 		set := make(map[datalog.String]struct{}, len(input.NotInSet))
 		for _, s := range input.NotInSet {
 			set[datalog.String(s)] = struct{}{}
@@ -655,15 +570,15 @@ func protoStrConstraintToTokenStrConstraint(input *pb.StringConstraint) (*datalo
 			Set: set,
 			Not: true,
 		}
-	case pb.StringConstraint_PREFIX:
+	case pb.StringConstraintV0_PREFIX:
 		checker = datalog.StringComparisonChecker{
 			Comparison: datalog.StringComparisonPrefix,
 			Str:        datalog.String(input.Prefix),
 		}
-	case pb.StringConstraint_REGEX:
+	case pb.StringConstraintV0_REGEX:
 		re := datalog.StringRegexpChecker(*regexp.MustCompile(input.Regex))
 		checker = &re
-	case pb.StringConstraint_SUFFIX:
+	case pb.StringConstraintV0_SUFFIX:
 		checker = datalog.StringComparisonChecker{
 			Comparison: datalog.StringComparisonSuffix,
 			Str:        datalog.String(input.Suffix),
@@ -675,8 +590,8 @@ func protoStrConstraintToTokenStrConstraint(input *pb.StringConstraint) (*datalo
 	return &checker, nil
 }
 
-func tokenSymbolConstraintToProtoSymbolConstraint(input datalog.SymbolInChecker) *pb.SymbolConstraint {
-	var pbSymbolConstraint *pb.SymbolConstraint
+func tokenSymbolConstraintToProtoSymbolConstraintV0(input datalog.SymbolInChecker) *pb.SymbolConstraintV0 {
+	var pbSymbolConstraint *pb.SymbolConstraintV0
 
 	pbSet := make([]uint64, 0, len(input.Set))
 	for e := range input.Set {
@@ -684,23 +599,23 @@ func tokenSymbolConstraintToProtoSymbolConstraint(input datalog.SymbolInChecker)
 	}
 
 	if input.Not {
-		pbSymbolConstraint = &pb.SymbolConstraint{
-			Kind:     pb.SymbolConstraint_NOT_IN,
+		pbSymbolConstraint = &pb.SymbolConstraintV0{
+			Kind:     pb.SymbolConstraintV0_NOT_IN,
 			NotInSet: pbSet,
 		}
 	} else {
-		pbSymbolConstraint = &pb.SymbolConstraint{
-			Kind:  pb.SymbolConstraint_IN,
+		pbSymbolConstraint = &pb.SymbolConstraintV0{
+			Kind:  pb.SymbolConstraintV0_IN,
 			InSet: pbSet,
 		}
 	}
 	return pbSymbolConstraint
 }
 
-func protoSymbolConstraintToTokenSymbolConstraint(input *pb.SymbolConstraint) (*datalog.Checker, error) {
+func protoSymbolConstraintToTokenSymbolConstraintV0(input *pb.SymbolConstraintV0) (*datalog.Checker, error) {
 	var checker datalog.Checker
 	switch input.Kind {
-	case pb.SymbolConstraint_IN:
+	case pb.SymbolConstraintV0_IN:
 		set := make(map[datalog.Symbol]struct{}, len(input.InSet))
 		for _, s := range input.InSet {
 			set[datalog.Symbol(s)] = struct{}{}
@@ -709,7 +624,7 @@ func protoSymbolConstraintToTokenSymbolConstraint(input *pb.SymbolConstraint) (*
 			Set: set,
 			Not: false,
 		}
-	case pb.SymbolConstraint_NOT_IN:
+	case pb.SymbolConstraintV0_NOT_IN:
 		set := make(map[datalog.Symbol]struct{}, len(input.NotInSet))
 		for _, s := range input.NotInSet {
 			set[datalog.Symbol(s)] = struct{}{}
@@ -724,12 +639,12 @@ func protoSymbolConstraintToTokenSymbolConstraint(input *pb.SymbolConstraint) (*
 	return &checker, nil
 }
 
-func tokenBytesConstraintToProtoBytesConstraint(input datalog.BytesComparisonChecker) (*pb.BytesConstraint, error) {
-	var pbBytesConstraint *pb.BytesConstraint
+func tokenBytesConstraintToProtoBytesConstraintV0(input datalog.BytesComparisonChecker) (*pb.BytesConstraintV0, error) {
+	var pbBytesConstraint *pb.BytesConstraintV0
 	switch input.Comparison {
 	case datalog.BytesComparisonEqual:
-		pbBytesConstraint = &pb.BytesConstraint{
-			Kind:  pb.BytesConstraint_EQUAL,
+		pbBytesConstraint = &pb.BytesConstraintV0{
+			Kind:  pb.BytesConstraintV0_EQUAL,
 			Equal: input.Bytes,
 		}
 	default:
@@ -739,8 +654,8 @@ func tokenBytesConstraintToProtoBytesConstraint(input datalog.BytesComparisonChe
 	return pbBytesConstraint, nil
 }
 
-func tokenBytesInConstraintToProtoBytesConstraint(input datalog.BytesInChecker) (*pb.BytesConstraint, error) {
-	var pbBytesConstraint *pb.BytesConstraint
+func tokenBytesInConstraintToProtoBytesConstraintV0(input datalog.BytesInChecker) (*pb.BytesConstraintV0, error) {
+	var pbBytesConstraint *pb.BytesConstraintV0
 	pbSet := make([][]byte, 0, len(input.Set))
 	for e := range input.Set {
 		b, err := hex.DecodeString(e)
@@ -751,13 +666,13 @@ func tokenBytesInConstraintToProtoBytesConstraint(input datalog.BytesInChecker) 
 	}
 
 	if input.Not {
-		pbBytesConstraint = &pb.BytesConstraint{
-			Kind:     pb.BytesConstraint_NOT_IN,
+		pbBytesConstraint = &pb.BytesConstraintV0{
+			Kind:     pb.BytesConstraintV0_NOT_IN,
 			NotInSet: pbSet,
 		}
 	} else {
-		pbBytesConstraint = &pb.BytesConstraint{
-			Kind:  pb.BytesConstraint_IN,
+		pbBytesConstraint = &pb.BytesConstraintV0{
+			Kind:  pb.BytesConstraintV0_IN,
 			InSet: pbSet,
 		}
 	}
@@ -765,15 +680,15 @@ func tokenBytesInConstraintToProtoBytesConstraint(input datalog.BytesInChecker) 
 	return pbBytesConstraint, nil
 }
 
-func protoBytesConstraintToTokenBytesConstraint(input *pb.BytesConstraint) (*datalog.Checker, error) {
+func protoBytesConstraintToTokenBytesConstraintV0(input *pb.BytesConstraintV0) (*datalog.Checker, error) {
 	var checker datalog.Checker
 	switch input.Kind {
-	case pb.BytesConstraint_EQUAL:
+	case pb.BytesConstraintV0_EQUAL:
 		checker = datalog.BytesComparisonChecker{
 			Comparison: datalog.BytesComparisonEqual,
 			Bytes:      input.Equal,
 		}
-	case pb.BytesConstraint_IN:
+	case pb.BytesConstraintV0_IN:
 		set := make(map[string]struct{}, len(input.InSet))
 		for _, s := range input.InSet {
 			set[hex.EncodeToString(s)] = struct{}{}
@@ -782,7 +697,7 @@ func protoBytesConstraintToTokenBytesConstraint(input *pb.BytesConstraint) (*dat
 			Set: set,
 			Not: false,
 		}
-	case pb.BytesConstraint_NOT_IN:
+	case pb.BytesConstraintV0_NOT_IN:
 		set := make(map[string]struct{}, len(input.NotInSet))
 		for _, s := range input.NotInSet {
 			set[hex.EncodeToString(s)] = struct{}{}
@@ -798,37 +713,25 @@ func protoBytesConstraintToTokenBytesConstraint(input *pb.BytesConstraint) (*dat
 	return &checker, nil
 }
 
-func tokenSignatureToProtoSignature(ts *sig.TokenSignature) *pb.Signature {
-	params, z := ts.Encode()
-	return &pb.Signature{
-		Parameters: params,
-		Z:          z,
-	}
-}
-
-func protoSignatureToTokenSignature(ps *pb.Signature) (*sig.TokenSignature, error) {
-	return sig.Decode(ps.Parameters, ps.Z)
-}
-
-func tokenCaveatToProtoCaveat(input datalog.Caveat) (*pb.Caveat, error) {
-	pbQueries := make([]*pb.Rule, len(input.Queries))
+func tokenCaveatToProtoCaveatV0(input datalog.Caveat) (*pb.CaveatV0, error) {
+	pbQueries := make([]*pb.RuleV0, len(input.Queries))
 	for i, query := range input.Queries {
-		q, err := tokenRuleToProtoRule(query)
+		q, err := tokenRuleToProtoRuleV0(query)
 		if err != nil {
 			return nil, err
 		}
 		pbQueries[i] = q
 	}
 
-	return &pb.Caveat{
+	return &pb.CaveatV0{
 		Queries: pbQueries,
 	}, nil
 }
 
-func protoCaveatToTokenCaveat(input *pb.Caveat) (*datalog.Caveat, error) {
+func protoCaveatToTokenCaveatV0(input *pb.CaveatV0) (*datalog.Caveat, error) {
 	queries := make([]datalog.Rule, len(input.Queries))
 	for i, query := range input.Queries {
-		q, err := protoRuleToTokenRule(query)
+		q, err := protoRuleToTokenRuleV0(query)
 		if err != nil {
 			return nil, err
 		}

--- a/converters_v0_test.go
+++ b/converters_v0_test.go
@@ -14,12 +14,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestConstraintConvertDateComparison(t *testing.T) {
+func TestConstraintConvertDateComparisonV0(t *testing.T) {
 	now := time.Now()
 	testCases := []struct {
 		Desc     string
 		Input    datalog.DateComparisonChecker
-		Expected *pb.DateConstraint
+		Expected *pb.DateConstraintV0
 	}{
 		{
 			Desc: "date comparison after",
@@ -27,8 +27,8 @@ func TestConstraintConvertDateComparison(t *testing.T) {
 				Comparison: datalog.DateComparisonAfter,
 				Date:       datalog.Date(now.Unix()),
 			},
-			Expected: &pb.DateConstraint{
-				Kind:  pb.DateConstraint_AFTER,
+			Expected: &pb.DateConstraintV0{
+				Kind:  pb.DateConstraintV0_AFTER,
 				After: uint64(now.Unix()),
 			},
 		},
@@ -38,8 +38,8 @@ func TestConstraintConvertDateComparison(t *testing.T) {
 				Comparison: datalog.DateComparisonBefore,
 				Date:       datalog.Date(123456789),
 			},
-			Expected: &pb.DateConstraint{
-				Kind:   pb.DateConstraint_BEFORE,
+			Expected: &pb.DateConstraintV0{
+				Kind:   pb.DateConstraintV0_BEFORE,
 				Before: uint64(123456789),
 			},
 		},
@@ -53,29 +53,29 @@ func TestConstraintConvertDateComparison(t *testing.T) {
 				Name:    datalog.Variable(i),
 				Checker: testCase.Input,
 			}
-			out, err := tokenConstraintToProtoConstraint(*in)
+			out, err := tokenConstraintToProtoConstraintV0(*in)
 			require.NoError(t, err)
 
-			expected := &pb.Constraint{
+			expected := &pb.ConstraintV0{
 				Id:   i,
-				Kind: pb.Constraint_DATE,
+				Kind: pb.ConstraintV0_DATE,
 				Date: testCase.Expected,
 			}
 			require.Equal(t, expected, out)
 
-			dlout, err := protoConstraintToTokenConstraint(out)
+			dlout, err := protoConstraintToTokenConstraintV0(out)
 			require.NoError(t, err)
 			require.Equal(t, in, dlout)
 		})
 	}
 }
 
-func TestConstraintConvertIntegerComparison(t *testing.T) {
+func TestConstraintConvertIntegerComparisonV0(t *testing.T) {
 	n := rand.Int63()
 	testCases := []struct {
 		Desc     string
 		Input    datalog.IntegerComparisonChecker
-		Expected *pb.IntConstraint
+		Expected *pb.IntConstraintV0
 	}{
 		{
 			Desc: "int comparison equal",
@@ -83,8 +83,8 @@ func TestConstraintConvertIntegerComparison(t *testing.T) {
 				Comparison: datalog.IntegerComparisonEqual,
 				Integer:    datalog.Integer(n),
 			},
-			Expected: &pb.IntConstraint{
-				Kind:  pb.IntConstraint_EQUAL,
+			Expected: &pb.IntConstraintV0{
+				Kind:  pb.IntConstraintV0_EQUAL,
 				Equal: n,
 			},
 		},
@@ -94,8 +94,8 @@ func TestConstraintConvertIntegerComparison(t *testing.T) {
 				Comparison: datalog.IntegerComparisonGT,
 				Integer:    datalog.Integer(n),
 			},
-			Expected: &pb.IntConstraint{
-				Kind:   pb.IntConstraint_LARGER,
+			Expected: &pb.IntConstraintV0{
+				Kind:   pb.IntConstraintV0_LARGER,
 				Larger: n,
 			},
 		},
@@ -105,8 +105,8 @@ func TestConstraintConvertIntegerComparison(t *testing.T) {
 				Comparison: datalog.IntegerComparisonGTE,
 				Integer:    datalog.Integer(n),
 			},
-			Expected: &pb.IntConstraint{
-				Kind:          pb.IntConstraint_LARGER_OR_EQUAL,
+			Expected: &pb.IntConstraintV0{
+				Kind:          pb.IntConstraintV0_LARGER_OR_EQUAL,
 				LargerOrEqual: n,
 			},
 		},
@@ -116,8 +116,8 @@ func TestConstraintConvertIntegerComparison(t *testing.T) {
 				Comparison: datalog.IntegerComparisonLT,
 				Integer:    datalog.Integer(n),
 			},
-			Expected: &pb.IntConstraint{
-				Kind:  pb.IntConstraint_LOWER,
+			Expected: &pb.IntConstraintV0{
+				Kind:  pb.IntConstraintV0_LOWER,
 				Lower: n,
 			},
 		},
@@ -127,8 +127,8 @@ func TestConstraintConvertIntegerComparison(t *testing.T) {
 				Comparison: datalog.IntegerComparisonLTE,
 				Integer:    datalog.Integer(n),
 			},
-			Expected: &pb.IntConstraint{
-				Kind:         pb.IntConstraint_LOWER_OR_EQUAL,
+			Expected: &pb.IntConstraintV0{
+				Kind:         pb.IntConstraintV0_LOWER_OR_EQUAL,
 				LowerOrEqual: n,
 			},
 		},
@@ -142,23 +142,23 @@ func TestConstraintConvertIntegerComparison(t *testing.T) {
 				Checker: testCase.Input,
 			}
 
-			out, err := tokenConstraintToProtoConstraint(*in)
+			out, err := tokenConstraintToProtoConstraintV0(*in)
 			require.NoError(t, err)
-			expected := &pb.Constraint{
+			expected := &pb.ConstraintV0{
 				Id:   i,
-				Kind: pb.Constraint_INT,
+				Kind: pb.ConstraintV0_INT,
 				Int:  testCase.Expected,
 			}
 			require.Equal(t, expected, out)
 
-			dlout, err := protoConstraintToTokenConstraint(out)
+			dlout, err := protoConstraintToTokenConstraintV0(out)
 			require.NoError(t, err)
 			require.Equal(t, in, dlout)
 		})
 	}
 }
 
-func TestConstraintConvertIntegerIn(t *testing.T) {
+func TestConstraintConvertIntegerInV0(t *testing.T) {
 	n1 := rand.Int63()
 	n2 := rand.Int63()
 	n3 := rand.Int63()
@@ -166,7 +166,7 @@ func TestConstraintConvertIntegerIn(t *testing.T) {
 	testCases := []struct {
 		Desc     string
 		Input    datalog.IntegerInChecker
-		Expected *pb.IntConstraint
+		Expected *pb.IntConstraintV0
 	}{
 		{
 			Desc: "int comparison in",
@@ -178,8 +178,8 @@ func TestConstraintConvertIntegerIn(t *testing.T) {
 				},
 				Not: false,
 			},
-			Expected: &pb.IntConstraint{
-				Kind:  pb.IntConstraint_IN,
+			Expected: &pb.IntConstraintV0{
+				Kind:  pb.IntConstraintV0_IN,
 				InSet: []int64{n1, n2, n3},
 			},
 		},
@@ -193,8 +193,8 @@ func TestConstraintConvertIntegerIn(t *testing.T) {
 				},
 				Not: true,
 			},
-			Expected: &pb.IntConstraint{
-				Kind:     pb.IntConstraint_NOT_IN,
+			Expected: &pb.IntConstraintV0{
+				Kind:     pb.IntConstraintV0_NOT_IN,
 				NotInSet: []int64{n1, n2, n3},
 			},
 		},
@@ -207,11 +207,11 @@ func TestConstraintConvertIntegerIn(t *testing.T) {
 				Name:    datalog.Variable(i),
 				Checker: testCase.Input,
 			}
-			out, err := tokenConstraintToProtoConstraint(*in)
+			out, err := tokenConstraintToProtoConstraintV0(*in)
 			require.NoError(t, err)
-			expected := &pb.Constraint{
+			expected := &pb.ConstraintV0{
 				Id:   i,
-				Kind: pb.Constraint_INT,
+				Kind: pb.ConstraintV0_INT,
 				Int:  testCase.Expected,
 			}
 
@@ -228,18 +228,18 @@ func TestConstraintConvertIntegerIn(t *testing.T) {
 
 			require.Equal(t, expected, out)
 
-			dlout, err := protoConstraintToTokenConstraint(out)
+			dlout, err := protoConstraintToTokenConstraintV0(out)
 			require.NoError(t, err)
 			require.Equal(t, in, dlout)
 		})
 	}
 }
 
-func TestConstraintConvertStringComparison(t *testing.T) {
+func TestConstraintConvertStringComparisonV0(t *testing.T) {
 	testCases := []struct {
 		Desc     string
 		Input    datalog.StringComparisonChecker
-		Expected *pb.StringConstraint
+		Expected *pb.StringConstraintV0
 	}{
 		{
 			Desc: "string comparison equal",
@@ -247,8 +247,8 @@ func TestConstraintConvertStringComparison(t *testing.T) {
 				Comparison: datalog.StringComparisonEqual,
 				Str:        "abcd",
 			},
-			Expected: &pb.StringConstraint{
-				Kind:  pb.StringConstraint_EQUAL,
+			Expected: &pb.StringConstraintV0{
+				Kind:  pb.StringConstraintV0_EQUAL,
 				Equal: "abcd",
 			},
 		},
@@ -258,8 +258,8 @@ func TestConstraintConvertStringComparison(t *testing.T) {
 				Comparison: datalog.StringComparisonPrefix,
 				Str:        "abcd",
 			},
-			Expected: &pb.StringConstraint{
-				Kind:   pb.StringConstraint_PREFIX,
+			Expected: &pb.StringConstraintV0{
+				Kind:   pb.StringConstraintV0_PREFIX,
 				Prefix: "abcd",
 			},
 		},
@@ -269,8 +269,8 @@ func TestConstraintConvertStringComparison(t *testing.T) {
 				Comparison: datalog.StringComparisonSuffix,
 				Str:        "abcd",
 			},
-			Expected: &pb.StringConstraint{
-				Kind:   pb.StringConstraint_SUFFIX,
+			Expected: &pb.StringConstraintV0{
+				Kind:   pb.StringConstraintV0_SUFFIX,
 				Suffix: "abcd",
 			},
 		},
@@ -283,30 +283,30 @@ func TestConstraintConvertStringComparison(t *testing.T) {
 				Name:    datalog.Variable(i),
 				Checker: testCase.Input,
 			}
-			out, err := tokenConstraintToProtoConstraint(*in)
+			out, err := tokenConstraintToProtoConstraintV0(*in)
 			require.NoError(t, err)
-			expected := &pb.Constraint{
+			expected := &pb.ConstraintV0{
 				Id:   i,
-				Kind: pb.Constraint_STRING,
+				Kind: pb.ConstraintV0_STRING,
 				Str:  testCase.Expected,
 			}
 			require.Equal(t, expected, out)
 
-			dlout, err := protoConstraintToTokenConstraint(out)
+			dlout, err := protoConstraintToTokenConstraintV0(out)
 			require.NoError(t, err)
 			require.Equal(t, in, dlout)
 		})
 	}
 }
 
-func TestConstraintConvertStringIn(t *testing.T) {
+func TestConstraintConvertStringInV0(t *testing.T) {
 	s1 := "abcd"
 	s2 := "efgh"
 
 	testCases := []struct {
 		Desc     string
 		Input    datalog.StringInChecker
-		Expected *pb.StringConstraint
+		Expected *pb.StringConstraintV0
 	}{
 		{
 			Desc: "string comparison in",
@@ -314,8 +314,8 @@ func TestConstraintConvertStringIn(t *testing.T) {
 				Set: map[datalog.String]struct{}{datalog.String(s1): {}, datalog.String(s2): {}},
 				Not: false,
 			},
-			Expected: &pb.StringConstraint{
-				Kind:  pb.StringConstraint_IN,
+			Expected: &pb.StringConstraintV0{
+				Kind:  pb.StringConstraintV0_IN,
 				InSet: []string{s1, s2},
 			},
 		},
@@ -325,8 +325,8 @@ func TestConstraintConvertStringIn(t *testing.T) {
 				Set: map[datalog.String]struct{}{datalog.String(s1): {}, datalog.String(s2): {}},
 				Not: true,
 			},
-			Expected: &pb.StringConstraint{
-				Kind:     pb.StringConstraint_NOT_IN,
+			Expected: &pb.StringConstraintV0{
+				Kind:     pb.StringConstraintV0_NOT_IN,
 				NotInSet: []string{s1, s2},
 			},
 		},
@@ -339,11 +339,11 @@ func TestConstraintConvertStringIn(t *testing.T) {
 				Name:    datalog.Variable(i),
 				Checker: testCase.Input,
 			}
-			out, err := tokenConstraintToProtoConstraint(*in)
+			out, err := tokenConstraintToProtoConstraintV0(*in)
 			require.NoError(t, err)
-			expected := &pb.Constraint{
+			expected := &pb.ConstraintV0{
 				Id:   i,
-				Kind: pb.Constraint_STRING,
+				Kind: pb.ConstraintV0_STRING,
 				Str:  testCase.Expected,
 			}
 
@@ -354,27 +354,27 @@ func TestConstraintConvertStringIn(t *testing.T) {
 
 			require.Equal(t, expected, out)
 
-			dlout, err := protoConstraintToTokenConstraint(out)
+			dlout, err := protoConstraintToTokenConstraintV0(out)
 			require.NoError(t, err)
 			require.Equal(t, in, dlout)
 		})
 	}
 }
 
-func TestConstraintConvertStringRegexp(t *testing.T) {
+func TestConstraintConvertStringRegexpV0(t *testing.T) {
 	re := regexp.MustCompile(`[a-z0-9_]+`)
 	dlre := datalog.StringRegexpChecker(*re)
 
 	testCases := []struct {
 		Desc     string
 		Input    *datalog.StringRegexpChecker
-		Expected *pb.StringConstraint
+		Expected *pb.StringConstraintV0
 	}{
 		{
 			Desc:  "string regexp",
 			Input: &dlre,
-			Expected: &pb.StringConstraint{
-				Kind:  pb.StringConstraint_REGEX,
+			Expected: &pb.StringConstraintV0{
+				Kind:  pb.StringConstraintV0_REGEX,
 				Regex: re.String(),
 			},
 		},
@@ -387,23 +387,23 @@ func TestConstraintConvertStringRegexp(t *testing.T) {
 				Name:    datalog.Variable(i),
 				Checker: testCase.Input,
 			}
-			out, err := tokenConstraintToProtoConstraint(*in)
+			out, err := tokenConstraintToProtoConstraintV0(*in)
 			require.NoError(t, err)
-			expected := &pb.Constraint{
+			expected := &pb.ConstraintV0{
 				Id:   i,
-				Kind: pb.Constraint_STRING,
+				Kind: pb.ConstraintV0_STRING,
 				Str:  testCase.Expected,
 			}
 			require.Equal(t, expected, out)
 
-			dlout, err := protoConstraintToTokenConstraint(out)
+			dlout, err := protoConstraintToTokenConstraintV0(out)
 			require.NoError(t, err)
 			require.Equal(t, in, dlout)
 		})
 	}
 }
 
-func TestConstraintConvertBytesComparison(t *testing.T) {
+func TestConstraintConvertBytesComparisonV0(t *testing.T) {
 	b := make([]byte, 64)
 	_, err := rand.Read(b)
 	require.NoError(t, err)
@@ -411,7 +411,7 @@ func TestConstraintConvertBytesComparison(t *testing.T) {
 	testCases := []struct {
 		Desc     string
 		Input    datalog.BytesComparisonChecker
-		Expected *pb.BytesConstraint
+		Expected *pb.BytesConstraintV0
 	}{
 		{
 			Desc: "bytes comparison equal",
@@ -419,8 +419,8 @@ func TestConstraintConvertBytesComparison(t *testing.T) {
 				Comparison: datalog.BytesComparisonEqual,
 				Bytes:      b,
 			},
-			Expected: &pb.BytesConstraint{
-				Kind:  pb.BytesConstraint_EQUAL,
+			Expected: &pb.BytesConstraintV0{
+				Kind:  pb.BytesConstraintV0_EQUAL,
 				Equal: b,
 			},
 		},
@@ -433,23 +433,23 @@ func TestConstraintConvertBytesComparison(t *testing.T) {
 				Name:    datalog.Variable(i),
 				Checker: testCase.Input,
 			}
-			out, err := tokenConstraintToProtoConstraint(*in)
+			out, err := tokenConstraintToProtoConstraintV0(*in)
 			require.NoError(t, err)
-			expected := &pb.Constraint{
+			expected := &pb.ConstraintV0{
 				Id:    i,
-				Kind:  pb.Constraint_BYTES,
+				Kind:  pb.ConstraintV0_BYTES,
 				Bytes: testCase.Expected,
 			}
 			require.Equal(t, expected, out)
 
-			dlout, err := protoConstraintToTokenConstraint(out)
+			dlout, err := protoConstraintToTokenConstraintV0(out)
 			require.NoError(t, err)
 			require.Equal(t, in, dlout)
 		})
 	}
 }
 
-func TestConstraintConvertBytesIn(t *testing.T) {
+func TestConstraintConvertBytesInV0(t *testing.T) {
 	b1 := make([]byte, 64)
 	_, err := rand.Read(b1)
 	require.NoError(t, err)
@@ -461,7 +461,7 @@ func TestConstraintConvertBytesIn(t *testing.T) {
 	testCases := []struct {
 		Desc     string
 		Input    datalog.BytesInChecker
-		Expected *pb.BytesConstraint
+		Expected *pb.BytesConstraintV0
 	}{
 		{
 			Desc: "bytes in",
@@ -469,8 +469,8 @@ func TestConstraintConvertBytesIn(t *testing.T) {
 				Set: map[string]struct{}{hex.EncodeToString(b1): {}, hex.EncodeToString(b2): {}},
 				Not: false,
 			},
-			Expected: &pb.BytesConstraint{
-				Kind:  pb.BytesConstraint_IN,
+			Expected: &pb.BytesConstraintV0{
+				Kind:  pb.BytesConstraintV0_IN,
 				InSet: [][]byte{b1, b2},
 			},
 		},
@@ -480,8 +480,8 @@ func TestConstraintConvertBytesIn(t *testing.T) {
 				Set: map[string]struct{}{hex.EncodeToString(b1): {}, hex.EncodeToString(b2): {}},
 				Not: true,
 			},
-			Expected: &pb.BytesConstraint{
-				Kind:     pb.BytesConstraint_NOT_IN,
+			Expected: &pb.BytesConstraintV0{
+				Kind:     pb.BytesConstraintV0_NOT_IN,
 				NotInSet: [][]byte{b1, b2},
 			},
 		},
@@ -494,11 +494,11 @@ func TestConstraintConvertBytesIn(t *testing.T) {
 				Name:    datalog.Variable(i),
 				Checker: testCase.Input,
 			}
-			out, err := tokenConstraintToProtoConstraint(*in)
+			out, err := tokenConstraintToProtoConstraintV0(*in)
 			require.NoError(t, err)
-			expected := &pb.Constraint{
+			expected := &pb.ConstraintV0{
 				Id:    i,
-				Kind:  pb.Constraint_BYTES,
+				Kind:  pb.ConstraintV0_BYTES,
 				Bytes: testCase.Expected,
 			}
 
@@ -515,14 +515,14 @@ func TestConstraintConvertBytesIn(t *testing.T) {
 
 			require.Equal(t, expected, out)
 
-			dlout, err := protoConstraintToTokenConstraint(out)
+			dlout, err := protoConstraintToTokenConstraintV0(out)
 			require.NoError(t, err)
 			require.Equal(t, in, dlout)
 		})
 	}
 }
 
-func TestConstraintConvertSymbolIn(t *testing.T) {
+func TestConstraintConvertSymbolInV0(t *testing.T) {
 	s1 := rand.Uint64()
 	s2 := rand.Uint64()
 	s3 := rand.Uint64()
@@ -530,7 +530,7 @@ func TestConstraintConvertSymbolIn(t *testing.T) {
 	testCases := []struct {
 		Desc     string
 		Input    datalog.SymbolInChecker
-		Expected *pb.SymbolConstraint
+		Expected *pb.SymbolConstraintV0
 	}{
 		{
 			Desc: "symbol in",
@@ -542,8 +542,8 @@ func TestConstraintConvertSymbolIn(t *testing.T) {
 				},
 				Not: false,
 			},
-			Expected: &pb.SymbolConstraint{
-				Kind:  pb.SymbolConstraint_IN,
+			Expected: &pb.SymbolConstraintV0{
+				Kind:  pb.SymbolConstraintV0_IN,
 				InSet: []uint64{s1, s2, s3},
 			},
 		},
@@ -557,8 +557,8 @@ func TestConstraintConvertSymbolIn(t *testing.T) {
 				},
 				Not: true,
 			},
-			Expected: &pb.SymbolConstraint{
-				Kind:     pb.SymbolConstraint_NOT_IN,
+			Expected: &pb.SymbolConstraintV0{
+				Kind:     pb.SymbolConstraintV0_NOT_IN,
 				NotInSet: []uint64{s1, s2, s3},
 			},
 		},
@@ -571,11 +571,11 @@ func TestConstraintConvertSymbolIn(t *testing.T) {
 				Name:    datalog.Variable(i),
 				Checker: testCase.Input,
 			}
-			out, err := tokenConstraintToProtoConstraint(*in)
+			out, err := tokenConstraintToProtoConstraintV0(*in)
 			require.NoError(t, err)
-			expected := &pb.Constraint{
+			expected := &pb.ConstraintV0{
 				Id:     i,
-				Kind:   pb.Constraint_SYMBOL,
+				Kind:   pb.ConstraintV0_SYMBOL,
 				Symbol: testCase.Expected,
 			}
 
@@ -592,14 +592,14 @@ func TestConstraintConvertSymbolIn(t *testing.T) {
 
 			require.Equal(t, expected, out)
 
-			dlout, err := protoConstraintToTokenConstraint(out)
+			dlout, err := protoConstraintToTokenConstraintV0(out)
 			require.NoError(t, err)
 			require.Equal(t, in, dlout)
 		})
 	}
 }
 
-func TestRuleConvert(t *testing.T) {
+func TestRuleConvertV0(t *testing.T) {
 	now := time.Now()
 
 	in := &datalog.Rule{
@@ -633,27 +633,27 @@ func TestRuleConvert(t *testing.T) {
 		},
 	}
 
-	expectedPbRule := &pb.Rule{
-		Head: &pb.Predicate{Name: 42, Ids: []*pb.ID{{Kind: pb.ID_INTEGER, Integer: 1}, {Kind: pb.ID_STR, Str: "id_1"}}},
-		Body: []*pb.Predicate{
-			{Name: 43, Ids: []*pb.ID{{Kind: pb.ID_SYMBOL, Symbol: 2}, {Kind: pb.ID_DATE, Date: uint64(now.Unix())}}},
-			{Name: 44, Ids: []*pb.ID{{Kind: pb.ID_BYTES, Bytes: []byte("abcd")}}},
+	expectedPbRule := &pb.RuleV0{
+		Head: &pb.PredicateV0{Name: 42, Ids: []*pb.IDV0{{Kind: pb.IDV0_INTEGER, Integer: 1}, {Kind: pb.IDV0_STR, Str: "id_1"}}},
+		Body: []*pb.PredicateV0{
+			{Name: 43, Ids: []*pb.IDV0{{Kind: pb.IDV0_SYMBOL, Symbol: 2}, {Kind: pb.IDV0_DATE, Date: uint64(now.Unix())}}},
+			{Name: 44, Ids: []*pb.IDV0{{Kind: pb.IDV0_BYTES, Bytes: []byte("abcd")}}},
 		},
-		Constraints: []*pb.Constraint{
-			{Id: 9, Kind: pb.Constraint_INT, Int: &pb.IntConstraint{Kind: pb.IntConstraint_EQUAL, Equal: 42}},
-			{Id: 99, Kind: pb.Constraint_STRING, Str: &pb.StringConstraint{Kind: pb.StringConstraint_PREFIX, Prefix: "abcd"}},
+		Constraints: []*pb.ConstraintV0{
+			{Id: 9, Kind: pb.ConstraintV0_INT, Int: &pb.IntConstraintV0{Kind: pb.IntConstraintV0_EQUAL, Equal: 42}},
+			{Id: 99, Kind: pb.ConstraintV0_STRING, Str: &pb.StringConstraintV0{Kind: pb.StringConstraintV0_PREFIX, Prefix: "abcd"}},
 		},
 	}
 
-	pbRule, err := tokenRuleToProtoRule(*in)
+	pbRule, err := tokenRuleToProtoRuleV0(*in)
 	require.NoError(t, err)
 	require.Equal(t, expectedPbRule, pbRule)
-	out, err := protoRuleToTokenRule(pbRule)
+	out, err := protoRuleToTokenRuleV0(pbRule)
 	require.NoError(t, err)
 	require.Equal(t, in, out)
 }
 
-func TestFactConvert(t *testing.T) {
+func TestFactConvertV0(t *testing.T) {
 	now := time.Now()
 	in := &datalog.Fact{Predicate: datalog.Predicate{
 		Name: datalog.Symbol(42),
@@ -672,41 +672,41 @@ func TestFactConvert(t *testing.T) {
 		},
 	}}
 
-	expectedPbFact := &pb.Fact{Predicate: &pb.Predicate{
+	expectedPbFact := &pb.FactV0{Predicate: &pb.PredicateV0{
 		Name: 42,
-		Ids: []*pb.ID{
-			{Kind: pb.ID_SYMBOL, Symbol: 1},
-			{Kind: pb.ID_INTEGER, Integer: 2},
-			{Kind: pb.ID_VARIABLE, Variable: 3},
-			{Kind: pb.ID_BYTES, Bytes: []byte("bytes")},
-			{Kind: pb.ID_STR, Str: "abcd"},
-			{Kind: pb.ID_DATE, Date: uint64(now.Unix())},
-			{Kind: pb.ID_SET, Set: []*pb.ID{
-				{Kind: pb.ID_STR, Str: "abc"},
-				{Kind: pb.ID_STR, Str: "def"},
-				{Kind: pb.ID_INTEGER, Integer: 42},
+		Ids: []*pb.IDV0{
+			{Kind: pb.IDV0_SYMBOL, Symbol: 1},
+			{Kind: pb.IDV0_INTEGER, Integer: 2},
+			{Kind: pb.IDV0_VARIABLE, Variable: 3},
+			{Kind: pb.IDV0_BYTES, Bytes: []byte("bytes")},
+			{Kind: pb.IDV0_STR, Str: "abcd"},
+			{Kind: pb.IDV0_DATE, Date: uint64(now.Unix())},
+			{Kind: pb.IDV0_SET, Set: []*pb.IDV0{
+				{Kind: pb.IDV0_STR, Str: "abc"},
+				{Kind: pb.IDV0_STR, Str: "def"},
+				{Kind: pb.IDV0_INTEGER, Integer: 42},
 			}},
 		},
 	}}
 
-	pbFact, err := tokenFactToProtoFact(*in)
+	pbFact, err := tokenFactToProtoFactV0(*in)
 	require.NoError(t, err)
 	require.Equal(t, expectedPbFact, pbFact)
 
-	out, err := protoFactToTokenFact(pbFact)
+	out, err := protoFactToTokenFactV0(pbFact)
 	require.NoError(t, err)
 	require.Equal(t, in, out)
 }
 
-func TestBlockConvert(t *testing.T) {
+func TestBlockConvertV0(t *testing.T) {
 	predicate := datalog.Predicate{
 		Name: datalog.Symbol(12),
 		IDs:  []datalog.ID{datalog.String("abcd")},
 	}
 
-	pbPredicate := &pb.Predicate{
+	pbPredicate := &pb.PredicateV0{
 		Name: 12,
-		Ids:  []*pb.ID{{Kind: pb.ID_STR, Str: "abcd"}},
+		Ids:  []*pb.IDV0{{Kind: pb.IDV0_STR, Str: "abcd"}},
 	}
 
 	rule := &datalog.Rule{
@@ -723,14 +723,14 @@ func TestBlockConvert(t *testing.T) {
 		},
 	}
 
-	pbRule := &pb.Rule{
+	pbRule := &pb.RuleV0{
 		Head: pbPredicate,
-		Body: []*pb.Predicate{pbPredicate},
-		Constraints: []*pb.Constraint{
+		Body: []*pb.PredicateV0{pbPredicate},
+		Constraints: []*pb.ConstraintV0{
 			{
 				Id:   13,
-				Kind: pb.Constraint_INT,
-				Int:  &pb.IntConstraint{Kind: pb.IntConstraint_EQUAL, Equal: 1234},
+				Kind: pb.ConstraintV0_INT,
+				Int:  &pb.IntConstraintV0{Kind: pb.IntConstraintV0_EQUAL, Equal: 1234},
 			},
 		},
 	}
@@ -747,12 +747,12 @@ func TestBlockConvert(t *testing.T) {
 	expectedPbBlock := &pb.Block{
 		Index:   42,
 		Symbols: []string{"a", "b", "c", "d"},
-		Facts: []*pb.Fact{
+		FactsV0: []*pb.FactV0{
 			{Predicate: pbPredicate},
 		},
-		Rules:   []*pb.Rule{pbRule},
-		Caveats: []*pb.Caveat{{Queries: []*pb.Rule{pbRule}}},
-		Context: "context",
+		RulesV0:   []*pb.RuleV0{pbRule},
+		CaveatsV0: []*pb.CaveatV0{{Queries: []*pb.RuleV0{pbRule}}},
+		Context:   "context",
 	}
 
 	pbBlock, err := tokenBlockToProtoBlock(in)

--- a/converters_v1.go
+++ b/converters_v1.go
@@ -1,0 +1,744 @@
+package biscuit
+
+import (
+	"encoding/hex"
+	"fmt"
+	"regexp"
+
+	"github.com/flynn/biscuit-go/datalog"
+	"github.com/flynn/biscuit-go/pb"
+)
+
+func tokenFactToProtoFactV1(input datalog.Fact) (*pb.FactV1, error) {
+	pred, err := tokenPredicateToProtoPredicateV1(input.Predicate)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pb.FactV1{
+		Predicate: pred,
+	}, nil
+}
+
+func protoFactToTokenFactV1(input *pb.FactV1) (*datalog.Fact, error) {
+	pred, err := protoPredicateToTokenPredicateV1(input.Predicate)
+	if err != nil {
+		return nil, err
+	}
+	return &datalog.Fact{
+		Predicate: *pred,
+	}, nil
+}
+
+func tokenPredicateToProtoPredicateV1(input datalog.Predicate) (*pb.PredicateV1, error) {
+	pbIds := make([]*pb.IDV1, len(input.IDs))
+	var err error
+	for i, id := range input.IDs {
+		pbIds[i], err = tokenIDToProtoIDV1(id)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &pb.PredicateV1{
+		Name: uint64(input.Name),
+		Ids:  pbIds,
+	}, nil
+}
+
+func protoPredicateToTokenPredicateV1(input *pb.PredicateV1) (*datalog.Predicate, error) {
+	ids := make([]datalog.ID, len(input.Ids))
+	for i, id := range input.Ids {
+		dlid, err := protoIDToTokenIDV1(id)
+		if err != nil {
+			return nil, err
+		}
+
+		ids[i] = *dlid
+	}
+
+	return &datalog.Predicate{
+		Name: datalog.Symbol(input.Name),
+		IDs:  ids,
+	}, nil
+}
+
+func tokenIDToProtoIDV1(input datalog.ID) (*pb.IDV1, error) {
+	var pbId *pb.IDV1
+	switch input.Type() {
+	case datalog.IDTypeString:
+		pbId = &pb.IDV1{
+			Kind: pb.IDV1_STR,
+			Str:  string(input.(datalog.String)),
+		}
+	case datalog.IDTypeDate:
+		pbId = &pb.IDV1{
+			Kind: pb.IDV1_DATE,
+			Date: uint64(input.(datalog.Date)),
+		}
+	case datalog.IDTypeInteger:
+		pbId = &pb.IDV1{
+			Kind:    pb.IDV1_INTEGER,
+			Integer: int64(input.(datalog.Integer)),
+		}
+	case datalog.IDTypeSymbol:
+		pbId = &pb.IDV1{
+			Kind:   pb.IDV1_SYMBOL,
+			Symbol: uint64(input.(datalog.Symbol)),
+		}
+	case datalog.IDTypeVariable:
+		pbId = &pb.IDV1{
+			Kind:     pb.IDV1_VARIABLE,
+			Variable: uint32(input.(datalog.Variable)),
+		}
+	case datalog.IDTypeBytes:
+		pbId = &pb.IDV1{
+			Kind:  pb.IDV1_BYTES,
+			Bytes: input.(datalog.Bytes),
+		}
+	case datalog.IDTypeSet:
+		datalogSet := input.(datalog.Set)
+		protoSet := make([]*pb.IDV1, 0, len(datalogSet))
+		for _, datalogElt := range datalogSet {
+			protoElt, err := tokenIDToProtoIDV1(datalogElt)
+			if err != nil {
+				return nil, err
+			}
+			protoSet = append(protoSet, protoElt)
+		}
+		pbId = &pb.IDV1{
+			Kind: pb.IDV1_SET,
+			Set:  protoSet,
+		}
+	default:
+		return nil, fmt.Errorf("biscuit: unsupported id type: %v", input.Type())
+	}
+	return pbId, nil
+}
+
+func protoIDToTokenIDV1(input *pb.IDV1) (*datalog.ID, error) {
+	var id datalog.ID
+	switch input.Kind {
+	case pb.IDV1_STR:
+		id = datalog.String(input.Str)
+	case pb.IDV1_DATE:
+		id = datalog.Date(input.Date)
+	case pb.IDV1_INTEGER:
+		id = datalog.Integer(input.Integer)
+	case pb.IDV1_SYMBOL:
+		id = datalog.Symbol(input.Symbol)
+	case pb.IDV1_VARIABLE:
+		id = datalog.Variable(input.Variable)
+	case pb.IDV1_BYTES:
+		id = datalog.Bytes(input.Bytes)
+	case pb.IDV1_SET:
+		datalogSet := make(datalog.Set, 0, len(input.Set))
+		for _, protoElt := range input.Set {
+			datalogElt, err := protoIDToTokenIDV1(protoElt)
+			if err != nil {
+				return nil, err
+			}
+			datalogSet = append(datalogSet, *datalogElt)
+		}
+		id = datalogSet
+	default:
+		return nil, fmt.Errorf("biscuit: unsupported id kind: %v", input.Kind)
+	}
+
+	return &id, nil
+}
+
+func tokenRuleToProtoRuleV1(input datalog.Rule) (*pb.RuleV1, error) {
+	pbBody := make([]*pb.PredicateV1, len(input.Body))
+	for i, p := range input.Body {
+		pred, err := tokenPredicateToProtoPredicateV1(p)
+		if err != nil {
+			return nil, err
+		}
+		pbBody[i] = pred
+	}
+
+	pbConstraints := make([]*pb.ConstraintV1, len(input.Constraints))
+	for i, c := range input.Constraints {
+		cons, err := tokenConstraintToProtoConstraintV1(c)
+		if err != nil {
+			return nil, err
+		}
+		pbConstraints[i] = cons
+	}
+
+	pbHead, err := tokenPredicateToProtoPredicateV1(input.Head)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pb.RuleV1{
+		Head:        pbHead,
+		Body:        pbBody,
+		Constraints: pbConstraints,
+	}, nil
+}
+
+func protoRuleToTokenRuleV1(input *pb.RuleV1) (*datalog.Rule, error) {
+	body := make([]datalog.Predicate, len(input.Body))
+	for i, pb := range input.Body {
+		b, err := protoPredicateToTokenPredicateV1(pb)
+		if err != nil {
+			return nil, err
+		}
+		body[i] = *b
+	}
+
+	constraints := make([]datalog.Constraint, len(input.Constraints))
+	for i, pbConstraint := range input.Constraints {
+		c, err := protoConstraintToTokenConstraintV1(pbConstraint)
+		if err != nil {
+			return nil, err
+		}
+		constraints[i] = *c
+	}
+
+	head, err := protoPredicateToTokenPredicateV1(input.Head)
+	if err != nil {
+		return nil, err
+	}
+	return &datalog.Rule{
+		Head:        *head,
+		Body:        body,
+		Constraints: constraints,
+	}, nil
+}
+
+func tokenConstraintToProtoConstraintV1(input datalog.Constraint) (*pb.ConstraintV1, error) {
+	var pbConstraint *pb.ConstraintV1
+	switch input.Checker.(type) {
+	case datalog.DateComparisonChecker:
+		c, err := tokenDateConstraintToProtoDateConstraintV1(input.Checker.(datalog.DateComparisonChecker))
+		if err != nil {
+			return nil, err
+		}
+		pbConstraint = &pb.ConstraintV1{
+			Id:   uint32(input.Name),
+			Kind: pb.ConstraintV1_DATE,
+			Date: c,
+		}
+	case datalog.IntegerComparisonChecker:
+		c, err := tokenIntConstraintToProtoIntConstraintV1(input.Checker.(datalog.IntegerComparisonChecker))
+		if err != nil {
+			return nil, err
+		}
+		pbConstraint = &pb.ConstraintV1{
+			Id:   uint32(input.Name),
+			Kind: pb.ConstraintV1_INT,
+			Int:  c,
+		}
+	case datalog.IntegerInChecker:
+		pbConstraint = &pb.ConstraintV1{
+			Id:   uint32(input.Name),
+			Kind: pb.ConstraintV1_INT,
+			Int:  tokenIntInConstraintToProtoIntConstraintV1(input.Checker.(datalog.IntegerInChecker)),
+		}
+	case datalog.StringComparisonChecker:
+		c, err := tokenStrConstraintToProtoStrConstraintV1(input.Checker.(datalog.StringComparisonChecker))
+		if err != nil {
+			return nil, err
+		}
+		pbConstraint = &pb.ConstraintV1{
+			Id:   uint32(input.Name),
+			Kind: pb.ConstraintV1_STRING,
+			Str:  c,
+		}
+	case datalog.StringInChecker:
+		pbConstraint = &pb.ConstraintV1{
+			Id:   uint32(input.Name),
+			Kind: pb.ConstraintV1_STRING,
+			Str:  tokenStrInConstraintToProtoStrConstraintV1(input.Checker.(datalog.StringInChecker)),
+		}
+	case *datalog.StringRegexpChecker:
+		pbConstraint = &pb.ConstraintV1{
+			Id:   uint32(input.Name),
+			Kind: pb.ConstraintV1_STRING,
+			Str: &pb.StringConstraintV1{
+				Kind:  pb.StringConstraintV1_REGEX,
+				Regex: (*regexp.Regexp)(input.Checker.(*datalog.StringRegexpChecker)).String(),
+			},
+		}
+	case datalog.SymbolInChecker:
+		pbConstraint = &pb.ConstraintV1{
+			Id:     uint32(input.Name),
+			Kind:   pb.ConstraintV1_SYMBOL,
+			Symbol: tokenSymbolConstraintToProtoSymbolConstraintV1(input.Checker.(datalog.SymbolInChecker)),
+		}
+	case datalog.BytesComparisonChecker:
+		c, err := tokenBytesConstraintToProtoBytesConstraintV1(input.Checker.(datalog.BytesComparisonChecker))
+		if err != nil {
+			return nil, err
+		}
+		pbConstraint = &pb.ConstraintV1{
+			Id:    uint32(input.Name),
+			Kind:  pb.ConstraintV1_BYTES,
+			Bytes: c,
+		}
+	case datalog.BytesInChecker:
+		c, err := tokenBytesInConstraintToProtoBytesConstraintV1(input.Checker.(datalog.BytesInChecker))
+		if err != nil {
+			return nil, err
+		}
+		pbConstraint = &pb.ConstraintV1{
+			Id:    uint32(input.Name),
+			Kind:  pb.ConstraintV1_BYTES,
+			Bytes: c,
+		}
+	default:
+		return nil, fmt.Errorf("biscuit: unsupported constraint type: %v", input.Name.Type())
+	}
+
+	return pbConstraint, nil
+}
+
+func protoConstraintToTokenConstraintV1(input *pb.ConstraintV1) (*datalog.Constraint, error) {
+	var constraint datalog.Constraint
+	switch input.Kind {
+	case pb.ConstraintV1_DATE:
+		c, err := protoDateConstraintToTokenDateConstraintV1(input.Date)
+		if err != nil {
+			return nil, err
+		}
+		constraint = datalog.Constraint{
+			Name:    datalog.Variable(input.Id),
+			Checker: *c,
+		}
+	case pb.ConstraintV1_INT:
+		c, err := protoIntConstraintToTokenIntConstraintV1(input.Int)
+		if err != nil {
+			return nil, err
+		}
+		constraint = datalog.Constraint{
+			Name:    datalog.Variable(input.Id),
+			Checker: *c,
+		}
+	case pb.ConstraintV1_STRING:
+		c, err := protoStrConstraintToTokenStrConstraintV1(input.Str)
+		if err != nil {
+			return nil, err
+		}
+		constraint = datalog.Constraint{
+			Name:    datalog.Variable(input.Id),
+			Checker: *c,
+		}
+	case pb.ConstraintV1_SYMBOL:
+		c, err := protoSymbolConstraintToTokenSymbolConstraintV1(input.Symbol)
+		if err != nil {
+			return nil, err
+		}
+		constraint = datalog.Constraint{
+			Name:    datalog.Variable(input.Id),
+			Checker: *c,
+		}
+	case pb.ConstraintV1_BYTES:
+		c, err := protoBytesConstraintToTokenBytesConstraintV1(input.Bytes)
+		if err != nil {
+			return nil, err
+		}
+		constraint = datalog.Constraint{
+			Name:    datalog.Variable(input.Id),
+			Checker: *c,
+		}
+	default:
+		return nil, fmt.Errorf("biscuit: unsupported constraint kind: %v", input.Kind)
+	}
+
+	return &constraint, nil
+}
+
+func tokenDateConstraintToProtoDateConstraintV1(input datalog.DateComparisonChecker) (*pb.DateConstraintV1, error) {
+	var pbDateConstraint *pb.DateConstraintV1
+	switch input.Comparison {
+	case datalog.DateComparisonBefore:
+		pbDateConstraint = &pb.DateConstraintV1{
+			Kind:   pb.DateConstraintV1_BEFORE,
+			Before: uint64(input.Date),
+		}
+	case datalog.DateComparisonAfter:
+		pbDateConstraint = &pb.DateConstraintV1{
+			Kind:  pb.DateConstraintV1_AFTER,
+			After: uint64(input.Date),
+		}
+	default:
+		return nil, fmt.Errorf("biscuit: unsupported date constraint: %v", input.Comparison)
+	}
+
+	return pbDateConstraint, nil
+}
+
+func protoDateConstraintToTokenDateConstraintV1(input *pb.DateConstraintV1) (*datalog.Checker, error) {
+	var checker datalog.Checker
+	switch input.Kind {
+	case pb.DateConstraintV1_BEFORE:
+		checker = datalog.DateComparisonChecker{
+			Comparison: datalog.DateComparisonBefore,
+			Date:       datalog.Date(input.Before),
+		}
+	case pb.DateConstraintV1_AFTER:
+		checker = datalog.DateComparisonChecker{
+			Comparison: datalog.DateComparisonAfter,
+			Date:       datalog.Date(input.After),
+		}
+	default:
+		return nil, fmt.Errorf("biscuit: unsupported date constraint kind: %v", input.Kind)
+	}
+	return &checker, nil
+}
+
+func tokenIntConstraintToProtoIntConstraintV1(input datalog.IntegerComparisonChecker) (*pb.IntConstraintV1, error) {
+	var pbIntConstraint *pb.IntConstraintV1
+	switch input.Comparison {
+	case datalog.IntegerComparisonEqual:
+		pbIntConstraint = &pb.IntConstraintV1{
+			Kind:  pb.IntConstraintV1_EQUAL,
+			Equal: int64(input.Integer),
+		}
+	case datalog.IntegerComparisonGT:
+		pbIntConstraint = &pb.IntConstraintV1{
+			Kind:   pb.IntConstraintV1_LARGER,
+			Larger: int64(input.Integer),
+		}
+	case datalog.IntegerComparisonGTE:
+		pbIntConstraint = &pb.IntConstraintV1{
+			Kind:          pb.IntConstraintV1_LARGER_OR_EQUAL,
+			LargerOrEqual: int64(input.Integer),
+		}
+	case datalog.IntegerComparisonLT:
+		pbIntConstraint = &pb.IntConstraintV1{
+			Kind:  pb.IntConstraintV1_LOWER,
+			Lower: int64(input.Integer),
+		}
+	case datalog.IntegerComparisonLTE:
+		pbIntConstraint = &pb.IntConstraintV1{
+			Kind:         pb.IntConstraintV1_LOWER_OR_EQUAL,
+			LowerOrEqual: int64(input.Integer),
+		}
+	default:
+		return nil, fmt.Errorf("biscuit: unsupported int constraint: %v", input.Comparison)
+	}
+	return pbIntConstraint, nil
+}
+
+func tokenIntInConstraintToProtoIntConstraintV1(input datalog.IntegerInChecker) *pb.IntConstraintV1 {
+	var pbIntConstraint *pb.IntConstraintV1
+
+	pbSet := make([]int64, 0, len(input.Set))
+	for e := range input.Set {
+		pbSet = append(pbSet, int64(e))
+	}
+
+	if input.Not {
+		pbIntConstraint = &pb.IntConstraintV1{
+			Kind:     pb.IntConstraintV1_NOT_IN,
+			NotInSet: pbSet,
+		}
+	} else {
+		pbIntConstraint = &pb.IntConstraintV1{
+			Kind:  pb.IntConstraintV1_IN,
+			InSet: pbSet,
+		}
+	}
+	return pbIntConstraint
+}
+
+func protoIntConstraintToTokenIntConstraintV1(input *pb.IntConstraintV1) (*datalog.Checker, error) {
+	var checker datalog.Checker
+	switch input.Kind {
+	case pb.IntConstraintV1_EQUAL:
+		checker = datalog.IntegerComparisonChecker{
+			Comparison: datalog.IntegerComparisonEqual,
+			Integer:    datalog.Integer(input.Equal),
+		}
+	case pb.IntConstraintV1_IN:
+		set := make(map[datalog.Integer]struct{}, len(input.InSet))
+		for _, i := range input.InSet {
+			set[datalog.Integer(i)] = struct{}{}
+		}
+		checker = datalog.IntegerInChecker{
+			Set: set,
+			Not: false,
+		}
+	case pb.IntConstraintV1_NOT_IN:
+		set := make(map[datalog.Integer]struct{}, len(input.NotInSet))
+		for _, i := range input.NotInSet {
+			set[datalog.Integer(i)] = struct{}{}
+		}
+		checker = datalog.IntegerInChecker{
+			Set: set,
+			Not: true,
+		}
+	case pb.IntConstraintV1_LARGER:
+		checker = datalog.IntegerComparisonChecker{
+			Comparison: datalog.IntegerComparisonGT,
+			Integer:    datalog.Integer(input.Larger),
+		}
+	case pb.IntConstraintV1_LARGER_OR_EQUAL:
+		checker = datalog.IntegerComparisonChecker{
+			Comparison: datalog.IntegerComparisonGTE,
+			Integer:    datalog.Integer(input.LargerOrEqual),
+		}
+	case pb.IntConstraintV1_LOWER:
+		checker = datalog.IntegerComparisonChecker{
+			Comparison: datalog.IntegerComparisonLT,
+			Integer:    datalog.Integer(input.Lower),
+		}
+	case pb.IntConstraintV1_LOWER_OR_EQUAL:
+		checker = datalog.IntegerComparisonChecker{
+			Comparison: datalog.IntegerComparisonLTE,
+			Integer:    datalog.Integer(input.LowerOrEqual),
+		}
+	default:
+		return nil, fmt.Errorf("biscuit: unsupported int constraint kind: %v", input.Kind)
+	}
+	return &checker, nil
+}
+
+func tokenStrConstraintToProtoStrConstraintV1(input datalog.StringComparisonChecker) (*pb.StringConstraintV1, error) {
+	var pbStrConstraint *pb.StringConstraintV1
+	switch input.Comparison {
+	case datalog.StringComparisonEqual:
+		pbStrConstraint = &pb.StringConstraintV1{
+			Kind:  pb.StringConstraintV1_EQUAL,
+			Equal: string(input.Str),
+		}
+	case datalog.StringComparisonPrefix:
+		pbStrConstraint = &pb.StringConstraintV1{
+			Kind:   pb.StringConstraintV1_PREFIX,
+			Prefix: string(input.Str),
+		}
+	case datalog.StringComparisonSuffix:
+		pbStrConstraint = &pb.StringConstraintV1{
+			Kind:   pb.StringConstraintV1_SUFFIX,
+			Suffix: string(input.Str),
+		}
+	default:
+		return nil, fmt.Errorf("biscuit: unsupported string constraint: %v", input.Comparison)
+	}
+	return pbStrConstraint, nil
+}
+
+func tokenStrInConstraintToProtoStrConstraintV1(input datalog.StringInChecker) *pb.StringConstraintV1 {
+	var pbStringConstraint *pb.StringConstraintV1
+
+	pbSet := make([]string, 0, len(input.Set))
+	for e := range input.Set {
+		pbSet = append(pbSet, string(e))
+	}
+
+	if input.Not {
+		pbStringConstraint = &pb.StringConstraintV1{
+			Kind:     pb.StringConstraintV1_NOT_IN,
+			NotInSet: pbSet,
+		}
+	} else {
+		pbStringConstraint = &pb.StringConstraintV1{
+			Kind:  pb.StringConstraintV1_IN,
+			InSet: pbSet,
+		}
+	}
+	return pbStringConstraint
+}
+
+func protoStrConstraintToTokenStrConstraintV1(input *pb.StringConstraintV1) (*datalog.Checker, error) {
+	var checker datalog.Checker
+	switch input.Kind {
+	case pb.StringConstraintV1_EQUAL:
+		checker = datalog.StringComparisonChecker{
+			Comparison: datalog.StringComparisonEqual,
+			Str:        datalog.String(input.Equal),
+		}
+	case pb.StringConstraintV1_IN:
+		set := make(map[datalog.String]struct{}, len(input.InSet))
+		for _, s := range input.InSet {
+			set[datalog.String(s)] = struct{}{}
+		}
+		checker = datalog.StringInChecker{
+			Set: set,
+			Not: false,
+		}
+	case pb.StringConstraintV1_NOT_IN:
+		set := make(map[datalog.String]struct{}, len(input.NotInSet))
+		for _, s := range input.NotInSet {
+			set[datalog.String(s)] = struct{}{}
+		}
+		checker = datalog.StringInChecker{
+			Set: set,
+			Not: true,
+		}
+	case pb.StringConstraintV1_PREFIX:
+		checker = datalog.StringComparisonChecker{
+			Comparison: datalog.StringComparisonPrefix,
+			Str:        datalog.String(input.Prefix),
+		}
+	case pb.StringConstraintV1_REGEX:
+		re := datalog.StringRegexpChecker(*regexp.MustCompile(input.Regex))
+		checker = &re
+	case pb.StringConstraintV1_SUFFIX:
+		checker = datalog.StringComparisonChecker{
+			Comparison: datalog.StringComparisonSuffix,
+			Str:        datalog.String(input.Suffix),
+		}
+	default:
+		return nil, fmt.Errorf("biscuit: unsupported string constraint kind: %v", input.Kind)
+	}
+
+	return &checker, nil
+}
+
+func tokenSymbolConstraintToProtoSymbolConstraintV1(input datalog.SymbolInChecker) *pb.SymbolConstraintV1 {
+	var pbSymbolConstraint *pb.SymbolConstraintV1
+
+	pbSet := make([]uint64, 0, len(input.Set))
+	for e := range input.Set {
+		pbSet = append(pbSet, uint64(e))
+	}
+
+	if input.Not {
+		pbSymbolConstraint = &pb.SymbolConstraintV1{
+			Kind:     pb.SymbolConstraintV1_NOT_IN,
+			NotInSet: pbSet,
+		}
+	} else {
+		pbSymbolConstraint = &pb.SymbolConstraintV1{
+			Kind:  pb.SymbolConstraintV1_IN,
+			InSet: pbSet,
+		}
+	}
+	return pbSymbolConstraint
+}
+
+func protoSymbolConstraintToTokenSymbolConstraintV1(input *pb.SymbolConstraintV1) (*datalog.Checker, error) {
+	var checker datalog.Checker
+	switch input.Kind {
+	case pb.SymbolConstraintV1_IN:
+		set := make(map[datalog.Symbol]struct{}, len(input.InSet))
+		for _, s := range input.InSet {
+			set[datalog.Symbol(s)] = struct{}{}
+		}
+		checker = datalog.SymbolInChecker{
+			Set: set,
+			Not: false,
+		}
+	case pb.SymbolConstraintV1_NOT_IN:
+		set := make(map[datalog.Symbol]struct{}, len(input.NotInSet))
+		for _, s := range input.NotInSet {
+			set[datalog.Symbol(s)] = struct{}{}
+		}
+		checker = datalog.SymbolInChecker{
+			Set: set,
+			Not: true,
+		}
+	default:
+		return nil, fmt.Errorf("biscuit: unsupported symbol constraint kind: %v", input.Kind)
+	}
+	return &checker, nil
+}
+
+func tokenBytesConstraintToProtoBytesConstraintV1(input datalog.BytesComparisonChecker) (*pb.BytesConstraintV1, error) {
+	var pbBytesConstraint *pb.BytesConstraintV1
+	switch input.Comparison {
+	case datalog.BytesComparisonEqual:
+		pbBytesConstraint = &pb.BytesConstraintV1{
+			Kind:  pb.BytesConstraintV1_EQUAL,
+			Equal: input.Bytes,
+		}
+	default:
+		return nil, fmt.Errorf("biscuit: unsupported bytes comparison: %v", input.Comparison)
+	}
+
+	return pbBytesConstraint, nil
+}
+
+func tokenBytesInConstraintToProtoBytesConstraintV1(input datalog.BytesInChecker) (*pb.BytesConstraintV1, error) {
+	var pbBytesConstraint *pb.BytesConstraintV1
+	pbSet := make([][]byte, 0, len(input.Set))
+	for e := range input.Set {
+		b, err := hex.DecodeString(e)
+		if err != nil {
+			return nil, fmt.Errorf("biscuit: failed to decode hex string %q: %v", e, err)
+		}
+		pbSet = append(pbSet, b)
+	}
+
+	if input.Not {
+		pbBytesConstraint = &pb.BytesConstraintV1{
+			Kind:     pb.BytesConstraintV1_NOT_IN,
+			NotInSet: pbSet,
+		}
+	} else {
+		pbBytesConstraint = &pb.BytesConstraintV1{
+			Kind:  pb.BytesConstraintV1_IN,
+			InSet: pbSet,
+		}
+	}
+
+	return pbBytesConstraint, nil
+}
+
+func protoBytesConstraintToTokenBytesConstraintV1(input *pb.BytesConstraintV1) (*datalog.Checker, error) {
+	var checker datalog.Checker
+	switch input.Kind {
+	case pb.BytesConstraintV1_EQUAL:
+		checker = datalog.BytesComparisonChecker{
+			Comparison: datalog.BytesComparisonEqual,
+			Bytes:      input.Equal,
+		}
+	case pb.BytesConstraintV1_IN:
+		set := make(map[string]struct{}, len(input.InSet))
+		for _, s := range input.InSet {
+			set[hex.EncodeToString(s)] = struct{}{}
+		}
+		checker = datalog.BytesInChecker{
+			Set: set,
+			Not: false,
+		}
+	case pb.BytesConstraintV1_NOT_IN:
+		set := make(map[string]struct{}, len(input.NotInSet))
+		for _, s := range input.NotInSet {
+			set[hex.EncodeToString(s)] = struct{}{}
+		}
+		checker = datalog.BytesInChecker{
+			Set: set,
+			Not: true,
+		}
+	default:
+		return nil, fmt.Errorf("biscuit: unsupported bytes constraint kind: %v", input.Kind)
+	}
+
+	return &checker, nil
+}
+
+func tokenCaveatToProtoCaveatV1(input datalog.Caveat) (*pb.CaveatV1, error) {
+	pbQueries := make([]*pb.RuleV1, len(input.Queries))
+	for i, query := range input.Queries {
+		q, err := tokenRuleToProtoRuleV1(query)
+		if err != nil {
+			return nil, err
+		}
+		pbQueries[i] = q
+	}
+
+	return &pb.CaveatV1{
+		Queries: pbQueries,
+	}, nil
+}
+
+func protoCaveatToTokenCaveatV1(input *pb.CaveatV1) (*datalog.Caveat, error) {
+	queries := make([]datalog.Rule, len(input.Queries))
+	for i, query := range input.Queries {
+		q, err := protoRuleToTokenRuleV1(query)
+		if err != nil {
+			return nil, err
+		}
+		queries[i] = *q
+	}
+
+	return &datalog.Caveat{
+		Queries: queries,
+	}, nil
+}

--- a/converters_v1_test.go
+++ b/converters_v1_test.go
@@ -1,0 +1,841 @@
+package biscuit
+
+import (
+	"encoding/hex"
+	"math/rand"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/flynn/biscuit-go/datalog"
+	"github.com/flynn/biscuit-go/pb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConstraintConvertDateComparisonV1(t *testing.T) {
+	now := time.Now()
+	testCases := []struct {
+		Desc     string
+		Input    datalog.DateComparisonChecker
+		Expected *pb.DateConstraintV1
+	}{
+		{
+			Desc: "date comparison after",
+			Input: datalog.DateComparisonChecker{
+				Comparison: datalog.DateComparisonAfter,
+				Date:       datalog.Date(now.Unix()),
+			},
+			Expected: &pb.DateConstraintV1{
+				Kind:  pb.DateConstraintV1_AFTER,
+				After: uint64(now.Unix()),
+			},
+		},
+		{
+			Desc: "date comparison before",
+			Input: datalog.DateComparisonChecker{
+				Comparison: datalog.DateComparisonBefore,
+				Date:       datalog.Date(123456789),
+			},
+			Expected: &pb.DateConstraintV1{
+				Kind:   pb.DateConstraintV1_BEFORE,
+				Before: uint64(123456789),
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Desc, func(t *testing.T) {
+			i := rand.Uint32()
+
+			in := &datalog.Constraint{
+				Name:    datalog.Variable(i),
+				Checker: testCase.Input,
+			}
+			out, err := tokenConstraintToProtoConstraintV1(*in)
+			require.NoError(t, err)
+
+			expected := &pb.ConstraintV1{
+				Id:   i,
+				Kind: pb.ConstraintV1_DATE,
+				Date: testCase.Expected,
+			}
+			require.Equal(t, expected, out)
+
+			dlout, err := protoConstraintToTokenConstraintV1(out)
+			require.NoError(t, err)
+			require.Equal(t, in, dlout)
+		})
+	}
+}
+
+func TestConstraintConvertIntegerComparisonV1(t *testing.T) {
+	n := rand.Int63()
+	testCases := []struct {
+		Desc     string
+		Input    datalog.IntegerComparisonChecker
+		Expected *pb.IntConstraintV1
+	}{
+		{
+			Desc: "int comparison equal",
+			Input: datalog.IntegerComparisonChecker{
+				Comparison: datalog.IntegerComparisonEqual,
+				Integer:    datalog.Integer(n),
+			},
+			Expected: &pb.IntConstraintV1{
+				Kind:  pb.IntConstraintV1_EQUAL,
+				Equal: n,
+			},
+		},
+		{
+			Desc: "int comparison larger",
+			Input: datalog.IntegerComparisonChecker{
+				Comparison: datalog.IntegerComparisonGT,
+				Integer:    datalog.Integer(n),
+			},
+			Expected: &pb.IntConstraintV1{
+				Kind:   pb.IntConstraintV1_LARGER,
+				Larger: n,
+			},
+		},
+		{
+			Desc: "int comparison larger or equal",
+			Input: datalog.IntegerComparisonChecker{
+				Comparison: datalog.IntegerComparisonGTE,
+				Integer:    datalog.Integer(n),
+			},
+			Expected: &pb.IntConstraintV1{
+				Kind:          pb.IntConstraintV1_LARGER_OR_EQUAL,
+				LargerOrEqual: n,
+			},
+		},
+		{
+			Desc: "int comparison lower",
+			Input: datalog.IntegerComparisonChecker{
+				Comparison: datalog.IntegerComparisonLT,
+				Integer:    datalog.Integer(n),
+			},
+			Expected: &pb.IntConstraintV1{
+				Kind:  pb.IntConstraintV1_LOWER,
+				Lower: n,
+			},
+		},
+		{
+			Desc: "int comparison lower or equal",
+			Input: datalog.IntegerComparisonChecker{
+				Comparison: datalog.IntegerComparisonLTE,
+				Integer:    datalog.Integer(n),
+			},
+			Expected: &pb.IntConstraintV1{
+				Kind:         pb.IntConstraintV1_LOWER_OR_EQUAL,
+				LowerOrEqual: n,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Desc, func(t *testing.T) {
+			i := rand.Uint32()
+			in := &datalog.Constraint{
+				Name:    datalog.Variable(i),
+				Checker: testCase.Input,
+			}
+
+			out, err := tokenConstraintToProtoConstraintV1(*in)
+			require.NoError(t, err)
+			expected := &pb.ConstraintV1{
+				Id:   i,
+				Kind: pb.ConstraintV1_INT,
+				Int:  testCase.Expected,
+			}
+			require.Equal(t, expected, out)
+
+			dlout, err := protoConstraintToTokenConstraintV1(out)
+			require.NoError(t, err)
+			require.Equal(t, in, dlout)
+		})
+	}
+}
+
+func TestConstraintConvertIntegerInV1(t *testing.T) {
+	n1 := rand.Int63()
+	n2 := rand.Int63()
+	n3 := rand.Int63()
+
+	testCases := []struct {
+		Desc     string
+		Input    datalog.IntegerInChecker
+		Expected *pb.IntConstraintV1
+	}{
+		{
+			Desc: "int comparison in",
+			Input: datalog.IntegerInChecker{
+				Set: map[datalog.Integer]struct{}{
+					datalog.Integer(n1): {},
+					datalog.Integer(n2): {},
+					datalog.Integer(n3): {},
+				},
+				Not: false,
+			},
+			Expected: &pb.IntConstraintV1{
+				Kind:  pb.IntConstraintV1_IN,
+				InSet: []int64{n1, n2, n3},
+			},
+		},
+		{
+			Desc: "int comparison not in",
+			Input: datalog.IntegerInChecker{
+				Set: map[datalog.Integer]struct{}{
+					datalog.Integer(n1): {},
+					datalog.Integer(n2): {},
+					datalog.Integer(n3): {},
+				},
+				Not: true,
+			},
+			Expected: &pb.IntConstraintV1{
+				Kind:     pb.IntConstraintV1_NOT_IN,
+				NotInSet: []int64{n1, n2, n3},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Desc, func(t *testing.T) {
+			i := rand.Uint32()
+			in := &datalog.Constraint{
+				Name:    datalog.Variable(i),
+				Checker: testCase.Input,
+			}
+			out, err := tokenConstraintToProtoConstraintV1(*in)
+			require.NoError(t, err)
+			expected := &pb.ConstraintV1{
+				Id:   i,
+				Kind: pb.ConstraintV1_INT,
+				Int:  testCase.Expected,
+			}
+
+			sortIt := func(s []int64) {
+				sort.Slice(s, func(i, j int) bool {
+					return s[i] < s[j]
+				})
+			}
+
+			sortIt(out.Int.InSet)
+			sortIt(expected.Int.InSet)
+			sortIt(out.Int.NotInSet)
+			sortIt(expected.Int.NotInSet)
+
+			require.Equal(t, expected, out)
+
+			dlout, err := protoConstraintToTokenConstraintV1(out)
+			require.NoError(t, err)
+			require.Equal(t, in, dlout)
+		})
+	}
+}
+
+func TestConstraintConvertStringComparisonV1(t *testing.T) {
+	testCases := []struct {
+		Desc     string
+		Input    datalog.StringComparisonChecker
+		Expected *pb.StringConstraintV1
+	}{
+		{
+			Desc: "string comparison equal",
+			Input: datalog.StringComparisonChecker{
+				Comparison: datalog.StringComparisonEqual,
+				Str:        "abcd",
+			},
+			Expected: &pb.StringConstraintV1{
+				Kind:  pb.StringConstraintV1_EQUAL,
+				Equal: "abcd",
+			},
+		},
+		{
+			Desc: "string comparison prefix",
+			Input: datalog.StringComparisonChecker{
+				Comparison: datalog.StringComparisonPrefix,
+				Str:        "abcd",
+			},
+			Expected: &pb.StringConstraintV1{
+				Kind:   pb.StringConstraintV1_PREFIX,
+				Prefix: "abcd",
+			},
+		},
+		{
+			Desc: "string comparison suffix",
+			Input: datalog.StringComparisonChecker{
+				Comparison: datalog.StringComparisonSuffix,
+				Str:        "abcd",
+			},
+			Expected: &pb.StringConstraintV1{
+				Kind:   pb.StringConstraintV1_SUFFIX,
+				Suffix: "abcd",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Desc, func(t *testing.T) {
+			i := rand.Uint32()
+			in := &datalog.Constraint{
+				Name:    datalog.Variable(i),
+				Checker: testCase.Input,
+			}
+			out, err := tokenConstraintToProtoConstraintV1(*in)
+			require.NoError(t, err)
+			expected := &pb.ConstraintV1{
+				Id:   i,
+				Kind: pb.ConstraintV1_STRING,
+				Str:  testCase.Expected,
+			}
+			require.Equal(t, expected, out)
+
+			dlout, err := protoConstraintToTokenConstraintV1(out)
+			require.NoError(t, err)
+			require.Equal(t, in, dlout)
+		})
+	}
+}
+
+func TestConstraintConvertStringInV1(t *testing.T) {
+	s1 := "abcd"
+	s2 := "efgh"
+
+	testCases := []struct {
+		Desc     string
+		Input    datalog.StringInChecker
+		Expected *pb.StringConstraintV1
+	}{
+		{
+			Desc: "string comparison in",
+			Input: datalog.StringInChecker{
+				Set: map[datalog.String]struct{}{datalog.String(s1): {}, datalog.String(s2): {}},
+				Not: false,
+			},
+			Expected: &pb.StringConstraintV1{
+				Kind:  pb.StringConstraintV1_IN,
+				InSet: []string{s1, s2},
+			},
+		},
+		{
+			Desc: "string comparison not in",
+			Input: datalog.StringInChecker{
+				Set: map[datalog.String]struct{}{datalog.String(s1): {}, datalog.String(s2): {}},
+				Not: true,
+			},
+			Expected: &pb.StringConstraintV1{
+				Kind:     pb.StringConstraintV1_NOT_IN,
+				NotInSet: []string{s1, s2},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Desc, func(t *testing.T) {
+			i := rand.Uint32()
+			in := &datalog.Constraint{
+				Name:    datalog.Variable(i),
+				Checker: testCase.Input,
+			}
+			out, err := tokenConstraintToProtoConstraintV1(*in)
+			require.NoError(t, err)
+			expected := &pb.ConstraintV1{
+				Id:   i,
+				Kind: pb.ConstraintV1_STRING,
+				Str:  testCase.Expected,
+			}
+
+			sort.Strings(expected.Str.InSet)
+			sort.Strings(out.Str.InSet)
+			sort.Strings(expected.Str.NotInSet)
+			sort.Strings(out.Str.NotInSet)
+
+			require.Equal(t, expected, out)
+
+			dlout, err := protoConstraintToTokenConstraintV1(out)
+			require.NoError(t, err)
+			require.Equal(t, in, dlout)
+		})
+	}
+}
+
+func TestConstraintConvertStringRegexpV1(t *testing.T) {
+	re := regexp.MustCompile(`[a-z0-9_]+`)
+	dlre := datalog.StringRegexpChecker(*re)
+
+	testCases := []struct {
+		Desc     string
+		Input    *datalog.StringRegexpChecker
+		Expected *pb.StringConstraintV1
+	}{
+		{
+			Desc:  "string regexp",
+			Input: &dlre,
+			Expected: &pb.StringConstraintV1{
+				Kind:  pb.StringConstraintV1_REGEX,
+				Regex: re.String(),
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Desc, func(t *testing.T) {
+			i := rand.Uint32()
+			in := &datalog.Constraint{
+				Name:    datalog.Variable(i),
+				Checker: testCase.Input,
+			}
+			out, err := tokenConstraintToProtoConstraintV1(*in)
+			require.NoError(t, err)
+			expected := &pb.ConstraintV1{
+				Id:   i,
+				Kind: pb.ConstraintV1_STRING,
+				Str:  testCase.Expected,
+			}
+			require.Equal(t, expected, out)
+
+			dlout, err := protoConstraintToTokenConstraintV1(out)
+			require.NoError(t, err)
+			require.Equal(t, in, dlout)
+		})
+	}
+}
+
+func TestConstraintConvertBytesComparisonV1(t *testing.T) {
+	b := make([]byte, 64)
+	_, err := rand.Read(b)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		Desc     string
+		Input    datalog.BytesComparisonChecker
+		Expected *pb.BytesConstraintV1
+	}{
+		{
+			Desc: "bytes comparison equal",
+			Input: datalog.BytesComparisonChecker{
+				Comparison: datalog.BytesComparisonEqual,
+				Bytes:      b,
+			},
+			Expected: &pb.BytesConstraintV1{
+				Kind:  pb.BytesConstraintV1_EQUAL,
+				Equal: b,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Desc, func(t *testing.T) {
+			i := rand.Uint32()
+			in := &datalog.Constraint{
+				Name:    datalog.Variable(i),
+				Checker: testCase.Input,
+			}
+			out, err := tokenConstraintToProtoConstraintV1(*in)
+			require.NoError(t, err)
+			expected := &pb.ConstraintV1{
+				Id:    i,
+				Kind:  pb.ConstraintV1_BYTES,
+				Bytes: testCase.Expected,
+			}
+			require.Equal(t, expected, out)
+
+			dlout, err := protoConstraintToTokenConstraintV1(out)
+			require.NoError(t, err)
+			require.Equal(t, in, dlout)
+		})
+	}
+}
+
+func TestConstraintConvertBytesInV1(t *testing.T) {
+	b1 := make([]byte, 64)
+	_, err := rand.Read(b1)
+	require.NoError(t, err)
+
+	b2 := make([]byte, 128)
+	_, err = rand.Read(b2)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		Desc     string
+		Input    datalog.BytesInChecker
+		Expected *pb.BytesConstraintV1
+	}{
+		{
+			Desc: "bytes in",
+			Input: datalog.BytesInChecker{
+				Set: map[string]struct{}{hex.EncodeToString(b1): {}, hex.EncodeToString(b2): {}},
+				Not: false,
+			},
+			Expected: &pb.BytesConstraintV1{
+				Kind:  pb.BytesConstraintV1_IN,
+				InSet: [][]byte{b1, b2},
+			},
+		},
+		{
+			Desc: "bytes not in",
+			Input: datalog.BytesInChecker{
+				Set: map[string]struct{}{hex.EncodeToString(b1): {}, hex.EncodeToString(b2): {}},
+				Not: true,
+			},
+			Expected: &pb.BytesConstraintV1{
+				Kind:     pb.BytesConstraintV1_NOT_IN,
+				NotInSet: [][]byte{b1, b2},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Desc, func(t *testing.T) {
+			i := rand.Uint32()
+			in := &datalog.Constraint{
+				Name:    datalog.Variable(i),
+				Checker: testCase.Input,
+			}
+			out, err := tokenConstraintToProtoConstraintV1(*in)
+			require.NoError(t, err)
+			expected := &pb.ConstraintV1{
+				Id:    i,
+				Kind:  pb.ConstraintV1_BYTES,
+				Bytes: testCase.Expected,
+			}
+
+			sortIt := func(s [][]byte) {
+				sort.Slice(s, func(i, j int) bool {
+					return strings.Compare(hex.EncodeToString(s[i]), hex.EncodeToString(s[j])) < 0
+				})
+			}
+
+			sortIt(out.Bytes.InSet)
+			sortIt(expected.Bytes.InSet)
+			sortIt(out.Bytes.NotInSet)
+			sortIt(expected.Bytes.NotInSet)
+
+			require.Equal(t, expected, out)
+
+			dlout, err := protoConstraintToTokenConstraintV1(out)
+			require.NoError(t, err)
+			require.Equal(t, in, dlout)
+		})
+	}
+}
+
+func TestConstraintConvertSymbolInV1(t *testing.T) {
+	s1 := rand.Uint64()
+	s2 := rand.Uint64()
+	s3 := rand.Uint64()
+
+	testCases := []struct {
+		Desc     string
+		Input    datalog.SymbolInChecker
+		Expected *pb.SymbolConstraintV1
+	}{
+		{
+			Desc: "symbol in",
+			Input: datalog.SymbolInChecker{
+				Set: map[datalog.Symbol]struct{}{
+					datalog.Symbol(s1): {},
+					datalog.Symbol(s2): {},
+					datalog.Symbol(s3): {},
+				},
+				Not: false,
+			},
+			Expected: &pb.SymbolConstraintV1{
+				Kind:  pb.SymbolConstraintV1_IN,
+				InSet: []uint64{s1, s2, s3},
+			},
+		},
+		{
+			Desc: "symbol not in",
+			Input: datalog.SymbolInChecker{
+				Set: map[datalog.Symbol]struct{}{
+					datalog.Symbol(s1): {},
+					datalog.Symbol(s2): {},
+					datalog.Symbol(s3): {},
+				},
+				Not: true,
+			},
+			Expected: &pb.SymbolConstraintV1{
+				Kind:     pb.SymbolConstraintV1_NOT_IN,
+				NotInSet: []uint64{s1, s2, s3},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Desc, func(t *testing.T) {
+			i := rand.Uint32()
+			in := &datalog.Constraint{
+				Name:    datalog.Variable(i),
+				Checker: testCase.Input,
+			}
+			out, err := tokenConstraintToProtoConstraintV1(*in)
+			require.NoError(t, err)
+			expected := &pb.ConstraintV1{
+				Id:     i,
+				Kind:   pb.ConstraintV1_SYMBOL,
+				Symbol: testCase.Expected,
+			}
+
+			sortIt := func(s []uint64) {
+				sort.Slice(s, func(i, j int) bool {
+					return s[i] < s[j]
+				})
+			}
+
+			sortIt(out.Symbol.InSet)
+			sortIt(expected.Symbol.InSet)
+			sortIt(out.Symbol.NotInSet)
+			sortIt(expected.Symbol.NotInSet)
+
+			require.Equal(t, expected, out)
+
+			dlout, err := protoConstraintToTokenConstraintV1(out)
+			require.NoError(t, err)
+			require.Equal(t, in, dlout)
+		})
+	}
+}
+
+func TestRuleConvertV1(t *testing.T) {
+	now := time.Now()
+
+	in := &datalog.Rule{
+		Head: datalog.Predicate{
+			Name: datalog.Symbol(42),
+			IDs:  []datalog.ID{datalog.Integer(1), datalog.String("id_1")},
+		},
+		Body: []datalog.Predicate{
+			{
+				Name: datalog.Symbol(43),
+				IDs:  []datalog.ID{datalog.Symbol(2), datalog.Date(now.Unix())},
+			}, {
+				Name: datalog.Symbol(44),
+				IDs:  []datalog.ID{datalog.Bytes([]byte("abcd"))},
+			},
+		},
+		Constraints: []datalog.Constraint{
+			{
+				Name: datalog.Variable(9),
+				Checker: datalog.IntegerComparisonChecker{
+					Comparison: datalog.IntegerComparisonEqual,
+					Integer:    42,
+				},
+			}, {
+				Name: datalog.Variable(99),
+				Checker: datalog.StringComparisonChecker{
+					Comparison: datalog.StringComparisonPrefix,
+					Str:        "abcd",
+				},
+			},
+		},
+	}
+
+	expectedPbRule := &pb.RuleV1{
+		Head: &pb.PredicateV1{Name: 42, Ids: []*pb.IDV1{{Kind: pb.IDV1_INTEGER, Integer: 1}, {Kind: pb.IDV1_STR, Str: "id_1"}}},
+		Body: []*pb.PredicateV1{
+			{Name: 43, Ids: []*pb.IDV1{{Kind: pb.IDV1_SYMBOL, Symbol: 2}, {Kind: pb.IDV1_DATE, Date: uint64(now.Unix())}}},
+			{Name: 44, Ids: []*pb.IDV1{{Kind: pb.IDV1_BYTES, Bytes: []byte("abcd")}}},
+		},
+		Constraints: []*pb.ConstraintV1{
+			{Id: 9, Kind: pb.ConstraintV1_INT, Int: &pb.IntConstraintV1{Kind: pb.IntConstraintV1_EQUAL, Equal: 42}},
+			{Id: 99, Kind: pb.ConstraintV1_STRING, Str: &pb.StringConstraintV1{Kind: pb.StringConstraintV1_PREFIX, Prefix: "abcd"}},
+		},
+	}
+
+	pbRule, err := tokenRuleToProtoRuleV1(*in)
+	require.NoError(t, err)
+	require.Equal(t, expectedPbRule, pbRule)
+	out, err := protoRuleToTokenRuleV1(pbRule)
+	require.NoError(t, err)
+	require.Equal(t, in, out)
+}
+
+func TestFactConvertV1(t *testing.T) {
+	now := time.Now()
+	in := &datalog.Fact{Predicate: datalog.Predicate{
+		Name: datalog.Symbol(42),
+		IDs: []datalog.ID{
+			datalog.Symbol(1),
+			datalog.Integer(2),
+			datalog.Variable(3),
+			datalog.Bytes([]byte("bytes")),
+			datalog.String("abcd"),
+			datalog.Date(now.Unix()),
+			datalog.Set{
+				datalog.String("abc"),
+				datalog.String("def"),
+				datalog.Integer(42),
+			},
+		},
+	}}
+
+	expectedPbFact := &pb.FactV1{Predicate: &pb.PredicateV1{
+		Name: 42,
+		Ids: []*pb.IDV1{
+			{Kind: pb.IDV1_SYMBOL, Symbol: 1},
+			{Kind: pb.IDV1_INTEGER, Integer: 2},
+			{Kind: pb.IDV1_VARIABLE, Variable: 3},
+			{Kind: pb.IDV1_BYTES, Bytes: []byte("bytes")},
+			{Kind: pb.IDV1_STR, Str: "abcd"},
+			{Kind: pb.IDV1_DATE, Date: uint64(now.Unix())},
+			{Kind: pb.IDV1_SET, Set: []*pb.IDV1{
+				{Kind: pb.IDV1_STR, Str: "abc"},
+				{Kind: pb.IDV1_STR, Str: "def"},
+				{Kind: pb.IDV1_INTEGER, Integer: 42},
+			}},
+		},
+	}}
+
+	pbFact, err := tokenFactToProtoFactV1(*in)
+	require.NoError(t, err)
+	require.Equal(t, expectedPbFact, pbFact)
+
+	out, err := protoFactToTokenFactV1(pbFact)
+	require.NoError(t, err)
+	require.Equal(t, in, out)
+}
+
+func TestBlockConvertV1(t *testing.T) {
+	predicate := datalog.Predicate{
+		Name: datalog.Symbol(12),
+		IDs:  []datalog.ID{datalog.String("abcd")},
+	}
+
+	pbPredicate := &pb.PredicateV1{
+		Name: 12,
+		Ids:  []*pb.IDV1{{Kind: pb.IDV1_STR, Str: "abcd"}},
+	}
+
+	rule := &datalog.Rule{
+		Head: predicate,
+		Body: []datalog.Predicate{predicate},
+		Constraints: []datalog.Constraint{
+			{
+				Name: datalog.Variable(13),
+				Checker: datalog.IntegerComparisonChecker{
+					Comparison: datalog.IntegerComparisonEqual,
+					Integer:    1234,
+				},
+			},
+		},
+	}
+
+	pbRule := &pb.RuleV1{
+		Head: pbPredicate,
+		Body: []*pb.PredicateV1{pbPredicate},
+		Constraints: []*pb.ConstraintV1{
+			{
+				Id:   13,
+				Kind: pb.ConstraintV1_INT,
+				Int:  &pb.IntConstraintV1{Kind: pb.IntConstraintV1_EQUAL, Equal: 1234},
+			},
+		},
+	}
+
+	in := &Block{
+		index:   42,
+		symbols: &datalog.SymbolTable{"a", "b", "c", "d"},
+		facts:   &datalog.FactSet{datalog.Fact{Predicate: predicate}},
+		rules:   []datalog.Rule{*rule},
+		caveats: []datalog.Caveat{{Queries: []datalog.Rule{*rule}}},
+		context: "context",
+		version: 1,
+	}
+
+	expectedPbBlock := &pb.Block{
+		Index:   42,
+		Symbols: []string{"a", "b", "c", "d"},
+		FactsV1: []*pb.FactV1{
+			{Predicate: pbPredicate},
+		},
+		RulesV1:   []*pb.RuleV1{pbRule},
+		CaveatsV1: []*pb.CaveatV1{{Queries: []*pb.RuleV1{pbRule}}},
+		Context:   "context",
+		Version:   1,
+	}
+
+	pbBlock, err := tokenBlockToProtoBlock(in)
+	require.NoError(t, err)
+	require.Equal(t, expectedPbBlock, pbBlock)
+
+	out, err := protoBlockToTokenBlock(pbBlock)
+	require.NoError(t, err)
+	require.Equal(t, in, out)
+
+	pbBlock.Version = MaxSchemaVersion + 1
+	_, err = protoBlockToTokenBlock(pbBlock)
+	require.Error(t, err)
+}
+
+func TestBlockConvertV1_BackwardCompat(t *testing.T) {
+	predicate := datalog.Predicate{
+		Name: datalog.Symbol(12),
+		IDs:  []datalog.ID{datalog.String("abcd")},
+	}
+	pbPredicate := &pb.PredicateV0{
+		Name: 12,
+		Ids:  []*pb.IDV0{{Kind: pb.IDV0_STR, Str: "abcd"}},
+	}
+
+	rule := &datalog.Rule{
+		Head: predicate,
+		Body: []datalog.Predicate{predicate},
+		Constraints: []datalog.Constraint{
+			{
+				Name: datalog.Variable(13),
+				Checker: datalog.IntegerComparisonChecker{
+					Comparison: datalog.IntegerComparisonEqual,
+					Integer:    1234,
+				},
+			},
+		},
+	}
+	pbRule := &pb.RuleV0{
+		Head: pbPredicate,
+		Body: []*pb.PredicateV0{pbPredicate},
+		Constraints: []*pb.ConstraintV0{
+			{
+				Id:   13,
+				Kind: pb.ConstraintV0_INT,
+				Int:  &pb.IntConstraintV0{Kind: pb.IntConstraintV0_EQUAL, Equal: 1234},
+			},
+		},
+	}
+
+	in := &Block{
+		index:   42,
+		symbols: &datalog.SymbolTable{"a", "b", "c", "d"},
+		facts:   &datalog.FactSet{datalog.Fact{Predicate: predicate}},
+		rules:   []datalog.Rule{*rule},
+		caveats: []datalog.Caveat{{Queries: []datalog.Rule{*rule}}},
+		context: "context",
+		version: 0,
+	}
+
+	expectedPbBlock := &pb.Block{
+		Index:   42,
+		Symbols: []string{"a", "b", "c", "d"},
+		FactsV0: []*pb.FactV0{
+			{Predicate: pbPredicate},
+		},
+		RulesV0:   []*pb.RuleV0{pbRule},
+		CaveatsV0: []*pb.CaveatV0{{Queries: []*pb.RuleV0{pbRule}}},
+		Context:   "context",
+		Version:   0,
+	}
+
+	pbBlock, err := tokenBlockToProtoBlock(in)
+	require.NoError(t, err)
+	require.Equal(t, expectedPbBlock, pbBlock)
+
+	out, err := protoBlockToTokenBlock(pbBlock)
+	require.NoError(t, err)
+	require.Equal(t, in, out)
+
+	pbBlock.Version = 1
+	_, err = protoBlockToTokenBlock(pbBlock)
+	require.NoError(t, err)
+}

--- a/example_test.go
+++ b/example_test.go
@@ -125,7 +125,7 @@ func ExampleBiscuit() {
 		fmt.Println("verified token")
 	}
 
-	// Output: Token1 length: 240
-	// Token2 length: 384
+	// Output: Token1 length: 242
+	// Token2 length: 388
 	// verified token
 }

--- a/pb/biscuit.pb.go
+++ b/pb/biscuit.pb.go
@@ -25,21 +25,21 @@ const (
 // of the legacy proto package is being used.
 const _ = proto.ProtoPackageIsVersion4
 
-type ID_Kind int32
+type IDV0_Kind int32
 
 const (
-	ID_SYMBOL   ID_Kind = 0
-	ID_VARIABLE ID_Kind = 1
-	ID_INTEGER  ID_Kind = 2
-	ID_STR      ID_Kind = 3
-	ID_DATE     ID_Kind = 4
-	ID_BYTES    ID_Kind = 5
-	ID_SET      ID_Kind = 6
+	IDV0_SYMBOL   IDV0_Kind = 0
+	IDV0_VARIABLE IDV0_Kind = 1
+	IDV0_INTEGER  IDV0_Kind = 2
+	IDV0_STR      IDV0_Kind = 3
+	IDV0_DATE     IDV0_Kind = 4
+	IDV0_BYTES    IDV0_Kind = 5
+	IDV0_SET      IDV0_Kind = 6
 )
 
-// Enum value maps for ID_Kind.
+// Enum value maps for IDV0_Kind.
 var (
-	ID_Kind_name = map[int32]string{
+	IDV0_Kind_name = map[int32]string{
 		0: "SYMBOL",
 		1: "VARIABLE",
 		2: "INTEGER",
@@ -48,7 +48,7 @@ var (
 		5: "BYTES",
 		6: "SET",
 	}
-	ID_Kind_value = map[string]int32{
+	IDV0_Kind_value = map[string]int32{
 		"SYMBOL":   0,
 		"VARIABLE": 1,
 		"INTEGER":  2,
@@ -59,47 +59,108 @@ var (
 	}
 )
 
-func (x ID_Kind) Enum() *ID_Kind {
-	p := new(ID_Kind)
+func (x IDV0_Kind) Enum() *IDV0_Kind {
+	p := new(IDV0_Kind)
 	*p = x
 	return p
 }
 
-func (x ID_Kind) String() string {
+func (x IDV0_Kind) String() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
-func (ID_Kind) Descriptor() protoreflect.EnumDescriptor {
+func (IDV0_Kind) Descriptor() protoreflect.EnumDescriptor {
 	return file_biscuit_proto_enumTypes[0].Descriptor()
 }
 
-func (ID_Kind) Type() protoreflect.EnumType {
+func (IDV0_Kind) Type() protoreflect.EnumType {
 	return &file_biscuit_proto_enumTypes[0]
 }
 
-func (x ID_Kind) Number() protoreflect.EnumNumber {
+func (x IDV0_Kind) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
-// Deprecated: Use ID_Kind.Descriptor instead.
-func (ID_Kind) EnumDescriptor() ([]byte, []int) {
-	return file_biscuit_proto_rawDescGZIP(), []int{8, 0}
+// Deprecated: Use IDV0_Kind.Descriptor instead.
+func (IDV0_Kind) EnumDescriptor() ([]byte, []int) {
+	return file_biscuit_proto_rawDescGZIP(), []int{12, 0}
 }
 
-type Constraint_Kind int32
+type IDV1_Kind int32
 
 const (
-	Constraint_INT    Constraint_Kind = 0
-	Constraint_STRING Constraint_Kind = 1
-	Constraint_DATE   Constraint_Kind = 2
-	Constraint_SYMBOL Constraint_Kind = 3
-	Constraint_BYTES  Constraint_Kind = 4
-	Constraint_SET    Constraint_Kind = 5
+	IDV1_SYMBOL   IDV1_Kind = 0
+	IDV1_VARIABLE IDV1_Kind = 1
+	IDV1_INTEGER  IDV1_Kind = 2
+	IDV1_STR      IDV1_Kind = 3
+	IDV1_DATE     IDV1_Kind = 4
+	IDV1_BYTES    IDV1_Kind = 5
+	IDV1_SET      IDV1_Kind = 6
 )
 
-// Enum value maps for Constraint_Kind.
+// Enum value maps for IDV1_Kind.
 var (
-	Constraint_Kind_name = map[int32]string{
+	IDV1_Kind_name = map[int32]string{
+		0: "SYMBOL",
+		1: "VARIABLE",
+		2: "INTEGER",
+		3: "STR",
+		4: "DATE",
+		5: "BYTES",
+		6: "SET",
+	}
+	IDV1_Kind_value = map[string]int32{
+		"SYMBOL":   0,
+		"VARIABLE": 1,
+		"INTEGER":  2,
+		"STR":      3,
+		"DATE":     4,
+		"BYTES":    5,
+		"SET":      6,
+	}
+)
+
+func (x IDV1_Kind) Enum() *IDV1_Kind {
+	p := new(IDV1_Kind)
+	*p = x
+	return p
+}
+
+func (x IDV1_Kind) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (IDV1_Kind) Descriptor() protoreflect.EnumDescriptor {
+	return file_biscuit_proto_enumTypes[1].Descriptor()
+}
+
+func (IDV1_Kind) Type() protoreflect.EnumType {
+	return &file_biscuit_proto_enumTypes[1]
+}
+
+func (x IDV1_Kind) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use IDV1_Kind.Descriptor instead.
+func (IDV1_Kind) EnumDescriptor() ([]byte, []int) {
+	return file_biscuit_proto_rawDescGZIP(), []int{13, 0}
+}
+
+type ConstraintV0_Kind int32
+
+const (
+	ConstraintV0_INT    ConstraintV0_Kind = 0
+	ConstraintV0_STRING ConstraintV0_Kind = 1
+	ConstraintV0_DATE   ConstraintV0_Kind = 2
+	ConstraintV0_SYMBOL ConstraintV0_Kind = 3
+	ConstraintV0_BYTES  ConstraintV0_Kind = 4
+	ConstraintV0_SET    ConstraintV0_Kind = 5
+)
+
+// Enum value maps for ConstraintV0_Kind.
+var (
+	ConstraintV0_Kind_name = map[int32]string{
 		0: "INT",
 		1: "STRING",
 		2: "DATE",
@@ -107,7 +168,7 @@ var (
 		4: "BYTES",
 		5: "SET",
 	}
-	Constraint_Kind_value = map[string]int32{
+	ConstraintV0_Kind_value = map[string]int32{
 		"INT":    0,
 		"STRING": 1,
 		"DATE":   2,
@@ -117,48 +178,106 @@ var (
 	}
 )
 
-func (x Constraint_Kind) Enum() *Constraint_Kind {
-	p := new(Constraint_Kind)
+func (x ConstraintV0_Kind) Enum() *ConstraintV0_Kind {
+	p := new(ConstraintV0_Kind)
 	*p = x
 	return p
 }
 
-func (x Constraint_Kind) String() string {
+func (x ConstraintV0_Kind) String() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
-func (Constraint_Kind) Descriptor() protoreflect.EnumDescriptor {
-	return file_biscuit_proto_enumTypes[1].Descriptor()
+func (ConstraintV0_Kind) Descriptor() protoreflect.EnumDescriptor {
+	return file_biscuit_proto_enumTypes[2].Descriptor()
 }
 
-func (Constraint_Kind) Type() protoreflect.EnumType {
-	return &file_biscuit_proto_enumTypes[1]
+func (ConstraintV0_Kind) Type() protoreflect.EnumType {
+	return &file_biscuit_proto_enumTypes[2]
 }
 
-func (x Constraint_Kind) Number() protoreflect.EnumNumber {
+func (x ConstraintV0_Kind) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
-// Deprecated: Use Constraint_Kind.Descriptor instead.
-func (Constraint_Kind) EnumDescriptor() ([]byte, []int) {
-	return file_biscuit_proto_rawDescGZIP(), []int{9, 0}
+// Deprecated: Use ConstraintV0_Kind.Descriptor instead.
+func (ConstraintV0_Kind) EnumDescriptor() ([]byte, []int) {
+	return file_biscuit_proto_rawDescGZIP(), []int{14, 0}
 }
 
-type IntConstraint_Kind int32
+type ConstraintV1_Kind int32
 
 const (
-	IntConstraint_LOWER           IntConstraint_Kind = 0
-	IntConstraint_LARGER          IntConstraint_Kind = 1
-	IntConstraint_LOWER_OR_EQUAL  IntConstraint_Kind = 2
-	IntConstraint_LARGER_OR_EQUAL IntConstraint_Kind = 3
-	IntConstraint_EQUAL           IntConstraint_Kind = 4
-	IntConstraint_IN              IntConstraint_Kind = 5
-	IntConstraint_NOT_IN          IntConstraint_Kind = 6
+	ConstraintV1_INT    ConstraintV1_Kind = 0
+	ConstraintV1_STRING ConstraintV1_Kind = 1
+	ConstraintV1_DATE   ConstraintV1_Kind = 2
+	ConstraintV1_SYMBOL ConstraintV1_Kind = 3
+	ConstraintV1_BYTES  ConstraintV1_Kind = 4
+	ConstraintV1_SET    ConstraintV1_Kind = 5
 )
 
-// Enum value maps for IntConstraint_Kind.
+// Enum value maps for ConstraintV1_Kind.
 var (
-	IntConstraint_Kind_name = map[int32]string{
+	ConstraintV1_Kind_name = map[int32]string{
+		0: "INT",
+		1: "STRING",
+		2: "DATE",
+		3: "SYMBOL",
+		4: "BYTES",
+		5: "SET",
+	}
+	ConstraintV1_Kind_value = map[string]int32{
+		"INT":    0,
+		"STRING": 1,
+		"DATE":   2,
+		"SYMBOL": 3,
+		"BYTES":  4,
+		"SET":    5,
+	}
+)
+
+func (x ConstraintV1_Kind) Enum() *ConstraintV1_Kind {
+	p := new(ConstraintV1_Kind)
+	*p = x
+	return p
+}
+
+func (x ConstraintV1_Kind) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ConstraintV1_Kind) Descriptor() protoreflect.EnumDescriptor {
+	return file_biscuit_proto_enumTypes[3].Descriptor()
+}
+
+func (ConstraintV1_Kind) Type() protoreflect.EnumType {
+	return &file_biscuit_proto_enumTypes[3]
+}
+
+func (x ConstraintV1_Kind) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ConstraintV1_Kind.Descriptor instead.
+func (ConstraintV1_Kind) EnumDescriptor() ([]byte, []int) {
+	return file_biscuit_proto_rawDescGZIP(), []int{15, 0}
+}
+
+type IntConstraintV0_Kind int32
+
+const (
+	IntConstraintV0_LOWER           IntConstraintV0_Kind = 0
+	IntConstraintV0_LARGER          IntConstraintV0_Kind = 1
+	IntConstraintV0_LOWER_OR_EQUAL  IntConstraintV0_Kind = 2
+	IntConstraintV0_LARGER_OR_EQUAL IntConstraintV0_Kind = 3
+	IntConstraintV0_EQUAL           IntConstraintV0_Kind = 4
+	IntConstraintV0_IN              IntConstraintV0_Kind = 5
+	IntConstraintV0_NOT_IN          IntConstraintV0_Kind = 6
+)
+
+// Enum value maps for IntConstraintV0_Kind.
+var (
+	IntConstraintV0_Kind_name = map[int32]string{
 		0: "LOWER",
 		1: "LARGER",
 		2: "LOWER_OR_EQUAL",
@@ -167,7 +286,7 @@ var (
 		5: "IN",
 		6: "NOT_IN",
 	}
-	IntConstraint_Kind_value = map[string]int32{
+	IntConstraintV0_Kind_value = map[string]int32{
 		"LOWER":           0,
 		"LARGER":          1,
 		"LOWER_OR_EQUAL":  2,
@@ -178,47 +297,108 @@ var (
 	}
 )
 
-func (x IntConstraint_Kind) Enum() *IntConstraint_Kind {
-	p := new(IntConstraint_Kind)
+func (x IntConstraintV0_Kind) Enum() *IntConstraintV0_Kind {
+	p := new(IntConstraintV0_Kind)
 	*p = x
 	return p
 }
 
-func (x IntConstraint_Kind) String() string {
+func (x IntConstraintV0_Kind) String() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
-func (IntConstraint_Kind) Descriptor() protoreflect.EnumDescriptor {
-	return file_biscuit_proto_enumTypes[2].Descriptor()
+func (IntConstraintV0_Kind) Descriptor() protoreflect.EnumDescriptor {
+	return file_biscuit_proto_enumTypes[4].Descriptor()
 }
 
-func (IntConstraint_Kind) Type() protoreflect.EnumType {
-	return &file_biscuit_proto_enumTypes[2]
+func (IntConstraintV0_Kind) Type() protoreflect.EnumType {
+	return &file_biscuit_proto_enumTypes[4]
 }
 
-func (x IntConstraint_Kind) Number() protoreflect.EnumNumber {
+func (x IntConstraintV0_Kind) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
-// Deprecated: Use IntConstraint_Kind.Descriptor instead.
-func (IntConstraint_Kind) EnumDescriptor() ([]byte, []int) {
-	return file_biscuit_proto_rawDescGZIP(), []int{10, 0}
+// Deprecated: Use IntConstraintV0_Kind.Descriptor instead.
+func (IntConstraintV0_Kind) EnumDescriptor() ([]byte, []int) {
+	return file_biscuit_proto_rawDescGZIP(), []int{16, 0}
 }
 
-type StringConstraint_Kind int32
+type IntConstraintV1_Kind int32
 
 const (
-	StringConstraint_PREFIX StringConstraint_Kind = 0
-	StringConstraint_SUFFIX StringConstraint_Kind = 1
-	StringConstraint_EQUAL  StringConstraint_Kind = 2
-	StringConstraint_IN     StringConstraint_Kind = 3
-	StringConstraint_NOT_IN StringConstraint_Kind = 4
-	StringConstraint_REGEX  StringConstraint_Kind = 5
+	IntConstraintV1_LOWER           IntConstraintV1_Kind = 0
+	IntConstraintV1_LARGER          IntConstraintV1_Kind = 1
+	IntConstraintV1_LOWER_OR_EQUAL  IntConstraintV1_Kind = 2
+	IntConstraintV1_LARGER_OR_EQUAL IntConstraintV1_Kind = 3
+	IntConstraintV1_EQUAL           IntConstraintV1_Kind = 4
+	IntConstraintV1_IN              IntConstraintV1_Kind = 5
+	IntConstraintV1_NOT_IN          IntConstraintV1_Kind = 6
 )
 
-// Enum value maps for StringConstraint_Kind.
+// Enum value maps for IntConstraintV1_Kind.
 var (
-	StringConstraint_Kind_name = map[int32]string{
+	IntConstraintV1_Kind_name = map[int32]string{
+		0: "LOWER",
+		1: "LARGER",
+		2: "LOWER_OR_EQUAL",
+		3: "LARGER_OR_EQUAL",
+		4: "EQUAL",
+		5: "IN",
+		6: "NOT_IN",
+	}
+	IntConstraintV1_Kind_value = map[string]int32{
+		"LOWER":           0,
+		"LARGER":          1,
+		"LOWER_OR_EQUAL":  2,
+		"LARGER_OR_EQUAL": 3,
+		"EQUAL":           4,
+		"IN":              5,
+		"NOT_IN":          6,
+	}
+)
+
+func (x IntConstraintV1_Kind) Enum() *IntConstraintV1_Kind {
+	p := new(IntConstraintV1_Kind)
+	*p = x
+	return p
+}
+
+func (x IntConstraintV1_Kind) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (IntConstraintV1_Kind) Descriptor() protoreflect.EnumDescriptor {
+	return file_biscuit_proto_enumTypes[5].Descriptor()
+}
+
+func (IntConstraintV1_Kind) Type() protoreflect.EnumType {
+	return &file_biscuit_proto_enumTypes[5]
+}
+
+func (x IntConstraintV1_Kind) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use IntConstraintV1_Kind.Descriptor instead.
+func (IntConstraintV1_Kind) EnumDescriptor() ([]byte, []int) {
+	return file_biscuit_proto_rawDescGZIP(), []int{17, 0}
+}
+
+type StringConstraintV0_Kind int32
+
+const (
+	StringConstraintV0_PREFIX StringConstraintV0_Kind = 0
+	StringConstraintV0_SUFFIX StringConstraintV0_Kind = 1
+	StringConstraintV0_EQUAL  StringConstraintV0_Kind = 2
+	StringConstraintV0_IN     StringConstraintV0_Kind = 3
+	StringConstraintV0_NOT_IN StringConstraintV0_Kind = 4
+	StringConstraintV0_REGEX  StringConstraintV0_Kind = 5
+)
+
+// Enum value maps for StringConstraintV0_Kind.
+var (
+	StringConstraintV0_Kind_name = map[int32]string{
 		0: "PREFIX",
 		1: "SUFFIX",
 		2: "EQUAL",
@@ -226,7 +406,7 @@ var (
 		4: "NOT_IN",
 		5: "REGEX",
 	}
-	StringConstraint_Kind_value = map[string]int32{
+	StringConstraintV0_Kind_value = map[string]int32{
 		"PREFIX": 0,
 		"SUFFIX": 1,
 		"EQUAL":  2,
@@ -236,172 +416,371 @@ var (
 	}
 )
 
-func (x StringConstraint_Kind) Enum() *StringConstraint_Kind {
-	p := new(StringConstraint_Kind)
+func (x StringConstraintV0_Kind) Enum() *StringConstraintV0_Kind {
+	p := new(StringConstraintV0_Kind)
 	*p = x
 	return p
 }
 
-func (x StringConstraint_Kind) String() string {
+func (x StringConstraintV0_Kind) String() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
-func (StringConstraint_Kind) Descriptor() protoreflect.EnumDescriptor {
-	return file_biscuit_proto_enumTypes[3].Descriptor()
+func (StringConstraintV0_Kind) Descriptor() protoreflect.EnumDescriptor {
+	return file_biscuit_proto_enumTypes[6].Descriptor()
 }
 
-func (StringConstraint_Kind) Type() protoreflect.EnumType {
-	return &file_biscuit_proto_enumTypes[3]
+func (StringConstraintV0_Kind) Type() protoreflect.EnumType {
+	return &file_biscuit_proto_enumTypes[6]
 }
 
-func (x StringConstraint_Kind) Number() protoreflect.EnumNumber {
+func (x StringConstraintV0_Kind) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
-// Deprecated: Use StringConstraint_Kind.Descriptor instead.
-func (StringConstraint_Kind) EnumDescriptor() ([]byte, []int) {
-	return file_biscuit_proto_rawDescGZIP(), []int{11, 0}
+// Deprecated: Use StringConstraintV0_Kind.Descriptor instead.
+func (StringConstraintV0_Kind) EnumDescriptor() ([]byte, []int) {
+	return file_biscuit_proto_rawDescGZIP(), []int{18, 0}
 }
 
-type DateConstraint_Kind int32
+type StringConstraintV1_Kind int32
 
 const (
-	DateConstraint_BEFORE DateConstraint_Kind = 0
-	DateConstraint_AFTER  DateConstraint_Kind = 1
+	StringConstraintV1_PREFIX StringConstraintV1_Kind = 0
+	StringConstraintV1_SUFFIX StringConstraintV1_Kind = 1
+	StringConstraintV1_EQUAL  StringConstraintV1_Kind = 2
+	StringConstraintV1_IN     StringConstraintV1_Kind = 3
+	StringConstraintV1_NOT_IN StringConstraintV1_Kind = 4
+	StringConstraintV1_REGEX  StringConstraintV1_Kind = 5
 )
 
-// Enum value maps for DateConstraint_Kind.
+// Enum value maps for StringConstraintV1_Kind.
 var (
-	DateConstraint_Kind_name = map[int32]string{
+	StringConstraintV1_Kind_name = map[int32]string{
+		0: "PREFIX",
+		1: "SUFFIX",
+		2: "EQUAL",
+		3: "IN",
+		4: "NOT_IN",
+		5: "REGEX",
+	}
+	StringConstraintV1_Kind_value = map[string]int32{
+		"PREFIX": 0,
+		"SUFFIX": 1,
+		"EQUAL":  2,
+		"IN":     3,
+		"NOT_IN": 4,
+		"REGEX":  5,
+	}
+)
+
+func (x StringConstraintV1_Kind) Enum() *StringConstraintV1_Kind {
+	p := new(StringConstraintV1_Kind)
+	*p = x
+	return p
+}
+
+func (x StringConstraintV1_Kind) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (StringConstraintV1_Kind) Descriptor() protoreflect.EnumDescriptor {
+	return file_biscuit_proto_enumTypes[7].Descriptor()
+}
+
+func (StringConstraintV1_Kind) Type() protoreflect.EnumType {
+	return &file_biscuit_proto_enumTypes[7]
+}
+
+func (x StringConstraintV1_Kind) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use StringConstraintV1_Kind.Descriptor instead.
+func (StringConstraintV1_Kind) EnumDescriptor() ([]byte, []int) {
+	return file_biscuit_proto_rawDescGZIP(), []int{19, 0}
+}
+
+type DateConstraintV0_Kind int32
+
+const (
+	DateConstraintV0_BEFORE DateConstraintV0_Kind = 0
+	DateConstraintV0_AFTER  DateConstraintV0_Kind = 1
+)
+
+// Enum value maps for DateConstraintV0_Kind.
+var (
+	DateConstraintV0_Kind_name = map[int32]string{
 		0: "BEFORE",
 		1: "AFTER",
 	}
-	DateConstraint_Kind_value = map[string]int32{
+	DateConstraintV0_Kind_value = map[string]int32{
 		"BEFORE": 0,
 		"AFTER":  1,
 	}
 )
 
-func (x DateConstraint_Kind) Enum() *DateConstraint_Kind {
-	p := new(DateConstraint_Kind)
+func (x DateConstraintV0_Kind) Enum() *DateConstraintV0_Kind {
+	p := new(DateConstraintV0_Kind)
 	*p = x
 	return p
 }
 
-func (x DateConstraint_Kind) String() string {
+func (x DateConstraintV0_Kind) String() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
-func (DateConstraint_Kind) Descriptor() protoreflect.EnumDescriptor {
-	return file_biscuit_proto_enumTypes[4].Descriptor()
+func (DateConstraintV0_Kind) Descriptor() protoreflect.EnumDescriptor {
+	return file_biscuit_proto_enumTypes[8].Descriptor()
 }
 
-func (DateConstraint_Kind) Type() protoreflect.EnumType {
-	return &file_biscuit_proto_enumTypes[4]
+func (DateConstraintV0_Kind) Type() protoreflect.EnumType {
+	return &file_biscuit_proto_enumTypes[8]
 }
 
-func (x DateConstraint_Kind) Number() protoreflect.EnumNumber {
+func (x DateConstraintV0_Kind) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
-// Deprecated: Use DateConstraint_Kind.Descriptor instead.
-func (DateConstraint_Kind) EnumDescriptor() ([]byte, []int) {
-	return file_biscuit_proto_rawDescGZIP(), []int{12, 0}
+// Deprecated: Use DateConstraintV0_Kind.Descriptor instead.
+func (DateConstraintV0_Kind) EnumDescriptor() ([]byte, []int) {
+	return file_biscuit_proto_rawDescGZIP(), []int{20, 0}
 }
 
-type SymbolConstraint_Kind int32
+type DateConstraintV1_Kind int32
 
 const (
-	SymbolConstraint_IN     SymbolConstraint_Kind = 0
-	SymbolConstraint_NOT_IN SymbolConstraint_Kind = 1
+	DateConstraintV1_BEFORE DateConstraintV1_Kind = 0
+	DateConstraintV1_AFTER  DateConstraintV1_Kind = 1
 )
 
-// Enum value maps for SymbolConstraint_Kind.
+// Enum value maps for DateConstraintV1_Kind.
 var (
-	SymbolConstraint_Kind_name = map[int32]string{
+	DateConstraintV1_Kind_name = map[int32]string{
+		0: "BEFORE",
+		1: "AFTER",
+	}
+	DateConstraintV1_Kind_value = map[string]int32{
+		"BEFORE": 0,
+		"AFTER":  1,
+	}
+)
+
+func (x DateConstraintV1_Kind) Enum() *DateConstraintV1_Kind {
+	p := new(DateConstraintV1_Kind)
+	*p = x
+	return p
+}
+
+func (x DateConstraintV1_Kind) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (DateConstraintV1_Kind) Descriptor() protoreflect.EnumDescriptor {
+	return file_biscuit_proto_enumTypes[9].Descriptor()
+}
+
+func (DateConstraintV1_Kind) Type() protoreflect.EnumType {
+	return &file_biscuit_proto_enumTypes[9]
+}
+
+func (x DateConstraintV1_Kind) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use DateConstraintV1_Kind.Descriptor instead.
+func (DateConstraintV1_Kind) EnumDescriptor() ([]byte, []int) {
+	return file_biscuit_proto_rawDescGZIP(), []int{21, 0}
+}
+
+type SymbolConstraintV0_Kind int32
+
+const (
+	SymbolConstraintV0_IN     SymbolConstraintV0_Kind = 0
+	SymbolConstraintV0_NOT_IN SymbolConstraintV0_Kind = 1
+)
+
+// Enum value maps for SymbolConstraintV0_Kind.
+var (
+	SymbolConstraintV0_Kind_name = map[int32]string{
 		0: "IN",
 		1: "NOT_IN",
 	}
-	SymbolConstraint_Kind_value = map[string]int32{
+	SymbolConstraintV0_Kind_value = map[string]int32{
 		"IN":     0,
 		"NOT_IN": 1,
 	}
 )
 
-func (x SymbolConstraint_Kind) Enum() *SymbolConstraint_Kind {
-	p := new(SymbolConstraint_Kind)
+func (x SymbolConstraintV0_Kind) Enum() *SymbolConstraintV0_Kind {
+	p := new(SymbolConstraintV0_Kind)
 	*p = x
 	return p
 }
 
-func (x SymbolConstraint_Kind) String() string {
+func (x SymbolConstraintV0_Kind) String() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
-func (SymbolConstraint_Kind) Descriptor() protoreflect.EnumDescriptor {
-	return file_biscuit_proto_enumTypes[5].Descriptor()
+func (SymbolConstraintV0_Kind) Descriptor() protoreflect.EnumDescriptor {
+	return file_biscuit_proto_enumTypes[10].Descriptor()
 }
 
-func (SymbolConstraint_Kind) Type() protoreflect.EnumType {
-	return &file_biscuit_proto_enumTypes[5]
+func (SymbolConstraintV0_Kind) Type() protoreflect.EnumType {
+	return &file_biscuit_proto_enumTypes[10]
 }
 
-func (x SymbolConstraint_Kind) Number() protoreflect.EnumNumber {
+func (x SymbolConstraintV0_Kind) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
-// Deprecated: Use SymbolConstraint_Kind.Descriptor instead.
-func (SymbolConstraint_Kind) EnumDescriptor() ([]byte, []int) {
-	return file_biscuit_proto_rawDescGZIP(), []int{13, 0}
+// Deprecated: Use SymbolConstraintV0_Kind.Descriptor instead.
+func (SymbolConstraintV0_Kind) EnumDescriptor() ([]byte, []int) {
+	return file_biscuit_proto_rawDescGZIP(), []int{22, 0}
 }
 
-type BytesConstraint_Kind int32
+type SymbolConstraintV1_Kind int32
 
 const (
-	BytesConstraint_EQUAL  BytesConstraint_Kind = 0
-	BytesConstraint_IN     BytesConstraint_Kind = 1
-	BytesConstraint_NOT_IN BytesConstraint_Kind = 2
+	SymbolConstraintV1_IN     SymbolConstraintV1_Kind = 0
+	SymbolConstraintV1_NOT_IN SymbolConstraintV1_Kind = 1
 )
 
-// Enum value maps for BytesConstraint_Kind.
+// Enum value maps for SymbolConstraintV1_Kind.
 var (
-	BytesConstraint_Kind_name = map[int32]string{
+	SymbolConstraintV1_Kind_name = map[int32]string{
+		0: "IN",
+		1: "NOT_IN",
+	}
+	SymbolConstraintV1_Kind_value = map[string]int32{
+		"IN":     0,
+		"NOT_IN": 1,
+	}
+)
+
+func (x SymbolConstraintV1_Kind) Enum() *SymbolConstraintV1_Kind {
+	p := new(SymbolConstraintV1_Kind)
+	*p = x
+	return p
+}
+
+func (x SymbolConstraintV1_Kind) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (SymbolConstraintV1_Kind) Descriptor() protoreflect.EnumDescriptor {
+	return file_biscuit_proto_enumTypes[11].Descriptor()
+}
+
+func (SymbolConstraintV1_Kind) Type() protoreflect.EnumType {
+	return &file_biscuit_proto_enumTypes[11]
+}
+
+func (x SymbolConstraintV1_Kind) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use SymbolConstraintV1_Kind.Descriptor instead.
+func (SymbolConstraintV1_Kind) EnumDescriptor() ([]byte, []int) {
+	return file_biscuit_proto_rawDescGZIP(), []int{23, 0}
+}
+
+type BytesConstraintV0_Kind int32
+
+const (
+	BytesConstraintV0_EQUAL  BytesConstraintV0_Kind = 0
+	BytesConstraintV0_IN     BytesConstraintV0_Kind = 1
+	BytesConstraintV0_NOT_IN BytesConstraintV0_Kind = 2
+)
+
+// Enum value maps for BytesConstraintV0_Kind.
+var (
+	BytesConstraintV0_Kind_name = map[int32]string{
 		0: "EQUAL",
 		1: "IN",
 		2: "NOT_IN",
 	}
-	BytesConstraint_Kind_value = map[string]int32{
+	BytesConstraintV0_Kind_value = map[string]int32{
 		"EQUAL":  0,
 		"IN":     1,
 		"NOT_IN": 2,
 	}
 )
 
-func (x BytesConstraint_Kind) Enum() *BytesConstraint_Kind {
-	p := new(BytesConstraint_Kind)
+func (x BytesConstraintV0_Kind) Enum() *BytesConstraintV0_Kind {
+	p := new(BytesConstraintV0_Kind)
 	*p = x
 	return p
 }
 
-func (x BytesConstraint_Kind) String() string {
+func (x BytesConstraintV0_Kind) String() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
-func (BytesConstraint_Kind) Descriptor() protoreflect.EnumDescriptor {
-	return file_biscuit_proto_enumTypes[6].Descriptor()
+func (BytesConstraintV0_Kind) Descriptor() protoreflect.EnumDescriptor {
+	return file_biscuit_proto_enumTypes[12].Descriptor()
 }
 
-func (BytesConstraint_Kind) Type() protoreflect.EnumType {
-	return &file_biscuit_proto_enumTypes[6]
+func (BytesConstraintV0_Kind) Type() protoreflect.EnumType {
+	return &file_biscuit_proto_enumTypes[12]
 }
 
-func (x BytesConstraint_Kind) Number() protoreflect.EnumNumber {
+func (x BytesConstraintV0_Kind) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
-// Deprecated: Use BytesConstraint_Kind.Descriptor instead.
-func (BytesConstraint_Kind) EnumDescriptor() ([]byte, []int) {
-	return file_biscuit_proto_rawDescGZIP(), []int{14, 0}
+// Deprecated: Use BytesConstraintV0_Kind.Descriptor instead.
+func (BytesConstraintV0_Kind) EnumDescriptor() ([]byte, []int) {
+	return file_biscuit_proto_rawDescGZIP(), []int{24, 0}
+}
+
+type BytesConstraintV1_Kind int32
+
+const (
+	BytesConstraintV1_EQUAL  BytesConstraintV1_Kind = 0
+	BytesConstraintV1_IN     BytesConstraintV1_Kind = 1
+	BytesConstraintV1_NOT_IN BytesConstraintV1_Kind = 2
+)
+
+// Enum value maps for BytesConstraintV1_Kind.
+var (
+	BytesConstraintV1_Kind_name = map[int32]string{
+		0: "EQUAL",
+		1: "IN",
+		2: "NOT_IN",
+	}
+	BytesConstraintV1_Kind_value = map[string]int32{
+		"EQUAL":  0,
+		"IN":     1,
+		"NOT_IN": 2,
+	}
+)
+
+func (x BytesConstraintV1_Kind) Enum() *BytesConstraintV1_Kind {
+	p := new(BytesConstraintV1_Kind)
+	*p = x
+	return p
+}
+
+func (x BytesConstraintV1_Kind) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (BytesConstraintV1_Kind) Descriptor() protoreflect.EnumDescriptor {
+	return file_biscuit_proto_enumTypes[13].Descriptor()
+}
+
+func (BytesConstraintV1_Kind) Type() protoreflect.EnumType {
+	return &file_biscuit_proto_enumTypes[13]
+}
+
+func (x BytesConstraintV1_Kind) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use BytesConstraintV1_Kind.Descriptor instead.
+func (BytesConstraintV1_Kind) EnumDescriptor() ([]byte, []int) {
+	return file_biscuit_proto_rawDescGZIP(), []int{25, 0}
 }
 
 type Biscuit struct {
@@ -598,13 +977,16 @@ type Block struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Index   uint32    `protobuf:"varint,1,opt,name=index,proto3" json:"index,omitempty"`
-	Symbols []string  `protobuf:"bytes,2,rep,name=symbols,proto3" json:"symbols,omitempty"`
-	Facts   []*Fact   `protobuf:"bytes,3,rep,name=facts,proto3" json:"facts,omitempty"`
-	Rules   []*Rule   `protobuf:"bytes,4,rep,name=rules,proto3" json:"rules,omitempty"`
-	Caveats []*Caveat `protobuf:"bytes,5,rep,name=caveats,proto3" json:"caveats,omitempty"`
-	Context string    `protobuf:"bytes,6,opt,name=context,proto3" json:"context,omitempty"`
-	Version uint32    `protobuf:"varint,7,opt,name=version,proto3" json:"version,omitempty"`
+	Index     uint32      `protobuf:"varint,1,opt,name=index,proto3" json:"index,omitempty"`
+	Symbols   []string    `protobuf:"bytes,2,rep,name=symbols,proto3" json:"symbols,omitempty"`
+	FactsV0   []*FactV0   `protobuf:"bytes,3,rep,name=facts_v0,json=factsV0,proto3" json:"facts_v0,omitempty"`
+	RulesV0   []*RuleV0   `protobuf:"bytes,4,rep,name=rules_v0,json=rulesV0,proto3" json:"rules_v0,omitempty"`
+	CaveatsV0 []*CaveatV0 `protobuf:"bytes,5,rep,name=caveats_v0,json=caveatsV0,proto3" json:"caveats_v0,omitempty"`
+	Context   string      `protobuf:"bytes,6,opt,name=context,proto3" json:"context,omitempty"`
+	Version   uint32      `protobuf:"varint,7,opt,name=version,proto3" json:"version,omitempty"`
+	FactsV1   []*FactV1   `protobuf:"bytes,8,rep,name=facts_v1,json=factsV1,proto3" json:"facts_v1,omitempty"`
+	RulesV1   []*RuleV1   `protobuf:"bytes,9,rep,name=rules_v1,json=rulesV1,proto3" json:"rules_v1,omitempty"`
+	CaveatsV1 []*CaveatV1 `protobuf:"bytes,10,rep,name=caveats_v1,json=caveatsV1,proto3" json:"caveats_v1,omitempty"`
 }
 
 func (x *Block) Reset() {
@@ -653,23 +1035,23 @@ func (x *Block) GetSymbols() []string {
 	return nil
 }
 
-func (x *Block) GetFacts() []*Fact {
+func (x *Block) GetFactsV0() []*FactV0 {
 	if x != nil {
-		return x.Facts
+		return x.FactsV0
 	}
 	return nil
 }
 
-func (x *Block) GetRules() []*Rule {
+func (x *Block) GetRulesV0() []*RuleV0 {
 	if x != nil {
-		return x.Rules
+		return x.RulesV0
 	}
 	return nil
 }
 
-func (x *Block) GetCaveats() []*Caveat {
+func (x *Block) GetCaveatsV0() []*CaveatV0 {
 	if x != nil {
-		return x.Caveats
+		return x.CaveatsV0
 	}
 	return nil
 }
@@ -688,16 +1070,37 @@ func (x *Block) GetVersion() uint32 {
 	return 0
 }
 
-type Fact struct {
+func (x *Block) GetFactsV1() []*FactV1 {
+	if x != nil {
+		return x.FactsV1
+	}
+	return nil
+}
+
+func (x *Block) GetRulesV1() []*RuleV1 {
+	if x != nil {
+		return x.RulesV1
+	}
+	return nil
+}
+
+func (x *Block) GetCaveatsV1() []*CaveatV1 {
+	if x != nil {
+		return x.CaveatsV1
+	}
+	return nil
+}
+
+type FactV0 struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Predicate *Predicate `protobuf:"bytes,1,opt,name=predicate,proto3" json:"predicate,omitempty"`
+	Predicate *PredicateV0 `protobuf:"bytes,1,opt,name=predicate,proto3" json:"predicate,omitempty"`
 }
 
-func (x *Fact) Reset() {
-	*x = Fact{}
+func (x *FactV0) Reset() {
+	*x = FactV0{}
 	if protoimpl.UnsafeEnabled {
 		mi := &file_biscuit_proto_msgTypes[4]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -705,13 +1108,13 @@ func (x *Fact) Reset() {
 	}
 }
 
-func (x *Fact) String() string {
+func (x *FactV0) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*Fact) ProtoMessage() {}
+func (*FactV0) ProtoMessage() {}
 
-func (x *Fact) ProtoReflect() protoreflect.Message {
+func (x *FactV0) ProtoReflect() protoreflect.Message {
 	mi := &file_biscuit_proto_msgTypes[4]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -723,30 +1126,28 @@ func (x *Fact) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use Fact.ProtoReflect.Descriptor instead.
-func (*Fact) Descriptor() ([]byte, []int) {
+// Deprecated: Use FactV0.ProtoReflect.Descriptor instead.
+func (*FactV0) Descriptor() ([]byte, []int) {
 	return file_biscuit_proto_rawDescGZIP(), []int{4}
 }
 
-func (x *Fact) GetPredicate() *Predicate {
+func (x *FactV0) GetPredicate() *PredicateV0 {
 	if x != nil {
 		return x.Predicate
 	}
 	return nil
 }
 
-type Rule struct {
+type FactV1 struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Head        *Predicate    `protobuf:"bytes,1,opt,name=head,proto3" json:"head,omitempty"`
-	Body        []*Predicate  `protobuf:"bytes,2,rep,name=body,proto3" json:"body,omitempty"`
-	Constraints []*Constraint `protobuf:"bytes,3,rep,name=constraints,proto3" json:"constraints,omitempty"`
+	Predicate *PredicateV1 `protobuf:"bytes,1,opt,name=predicate,proto3" json:"predicate,omitempty"`
 }
 
-func (x *Rule) Reset() {
-	*x = Rule{}
+func (x *FactV1) Reset() {
+	*x = FactV1{}
 	if protoimpl.UnsafeEnabled {
 		mi := &file_biscuit_proto_msgTypes[5]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -754,13 +1155,13 @@ func (x *Rule) Reset() {
 	}
 }
 
-func (x *Rule) String() string {
+func (x *FactV1) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*Rule) ProtoMessage() {}
+func (*FactV1) ProtoMessage() {}
 
-func (x *Rule) ProtoReflect() protoreflect.Message {
+func (x *FactV1) ProtoReflect() protoreflect.Message {
 	mi := &file_biscuit_proto_msgTypes[5]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -772,42 +1173,30 @@ func (x *Rule) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use Rule.ProtoReflect.Descriptor instead.
-func (*Rule) Descriptor() ([]byte, []int) {
+// Deprecated: Use FactV1.ProtoReflect.Descriptor instead.
+func (*FactV1) Descriptor() ([]byte, []int) {
 	return file_biscuit_proto_rawDescGZIP(), []int{5}
 }
 
-func (x *Rule) GetHead() *Predicate {
+func (x *FactV1) GetPredicate() *PredicateV1 {
 	if x != nil {
-		return x.Head
+		return x.Predicate
 	}
 	return nil
 }
 
-func (x *Rule) GetBody() []*Predicate {
-	if x != nil {
-		return x.Body
-	}
-	return nil
-}
-
-func (x *Rule) GetConstraints() []*Constraint {
-	if x != nil {
-		return x.Constraints
-	}
-	return nil
-}
-
-type Caveat struct {
+type RuleV0 struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Queries []*Rule `protobuf:"bytes,1,rep,name=queries,proto3" json:"queries,omitempty"`
+	Head        *PredicateV0    `protobuf:"bytes,1,opt,name=head,proto3" json:"head,omitempty"`
+	Body        []*PredicateV0  `protobuf:"bytes,2,rep,name=body,proto3" json:"body,omitempty"`
+	Constraints []*ConstraintV0 `protobuf:"bytes,3,rep,name=constraints,proto3" json:"constraints,omitempty"`
 }
 
-func (x *Caveat) Reset() {
-	*x = Caveat{}
+func (x *RuleV0) Reset() {
+	*x = RuleV0{}
 	if protoimpl.UnsafeEnabled {
 		mi := &file_biscuit_proto_msgTypes[6]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -815,13 +1204,13 @@ func (x *Caveat) Reset() {
 	}
 }
 
-func (x *Caveat) String() string {
+func (x *RuleV0) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*Caveat) ProtoMessage() {}
+func (*RuleV0) ProtoMessage() {}
 
-func (x *Caveat) ProtoReflect() protoreflect.Message {
+func (x *RuleV0) ProtoReflect() protoreflect.Message {
 	mi := &file_biscuit_proto_msgTypes[6]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -833,29 +1222,44 @@ func (x *Caveat) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use Caveat.ProtoReflect.Descriptor instead.
-func (*Caveat) Descriptor() ([]byte, []int) {
+// Deprecated: Use RuleV0.ProtoReflect.Descriptor instead.
+func (*RuleV0) Descriptor() ([]byte, []int) {
 	return file_biscuit_proto_rawDescGZIP(), []int{6}
 }
 
-func (x *Caveat) GetQueries() []*Rule {
+func (x *RuleV0) GetHead() *PredicateV0 {
 	if x != nil {
-		return x.Queries
+		return x.Head
 	}
 	return nil
 }
 
-type Predicate struct {
+func (x *RuleV0) GetBody() []*PredicateV0 {
+	if x != nil {
+		return x.Body
+	}
+	return nil
+}
+
+func (x *RuleV0) GetConstraints() []*ConstraintV0 {
+	if x != nil {
+		return x.Constraints
+	}
+	return nil
+}
+
+type RuleV1 struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Name uint64 `protobuf:"varint,1,opt,name=name,proto3" json:"name,omitempty"`
-	Ids  []*ID  `protobuf:"bytes,2,rep,name=ids,proto3" json:"ids,omitempty"`
+	Head        *PredicateV1    `protobuf:"bytes,1,opt,name=head,proto3" json:"head,omitempty"`
+	Body        []*PredicateV1  `protobuf:"bytes,2,rep,name=body,proto3" json:"body,omitempty"`
+	Constraints []*ConstraintV1 `protobuf:"bytes,3,rep,name=constraints,proto3" json:"constraints,omitempty"`
 }
 
-func (x *Predicate) Reset() {
-	*x = Predicate{}
+func (x *RuleV1) Reset() {
+	*x = RuleV1{}
 	if protoimpl.UnsafeEnabled {
 		mi := &file_biscuit_proto_msgTypes[7]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -863,13 +1267,13 @@ func (x *Predicate) Reset() {
 	}
 }
 
-func (x *Predicate) String() string {
+func (x *RuleV1) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*Predicate) ProtoMessage() {}
+func (*RuleV1) ProtoMessage() {}
 
-func (x *Predicate) ProtoReflect() protoreflect.Message {
+func (x *RuleV1) ProtoReflect() protoreflect.Message {
 	mi := &file_biscuit_proto_msgTypes[7]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -881,42 +1285,42 @@ func (x *Predicate) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use Predicate.ProtoReflect.Descriptor instead.
-func (*Predicate) Descriptor() ([]byte, []int) {
+// Deprecated: Use RuleV1.ProtoReflect.Descriptor instead.
+func (*RuleV1) Descriptor() ([]byte, []int) {
 	return file_biscuit_proto_rawDescGZIP(), []int{7}
 }
 
-func (x *Predicate) GetName() uint64 {
+func (x *RuleV1) GetHead() *PredicateV1 {
 	if x != nil {
-		return x.Name
-	}
-	return 0
-}
-
-func (x *Predicate) GetIds() []*ID {
-	if x != nil {
-		return x.Ids
+		return x.Head
 	}
 	return nil
 }
 
-type ID struct {
+func (x *RuleV1) GetBody() []*PredicateV1 {
+	if x != nil {
+		return x.Body
+	}
+	return nil
+}
+
+func (x *RuleV1) GetConstraints() []*ConstraintV1 {
+	if x != nil {
+		return x.Constraints
+	}
+	return nil
+}
+
+type CaveatV0 struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Kind     ID_Kind `protobuf:"varint,1,opt,name=kind,proto3,enum=ID_Kind" json:"kind,omitempty"`
-	Symbol   uint64  `protobuf:"varint,2,opt,name=symbol,proto3" json:"symbol,omitempty"`
-	Variable uint32  `protobuf:"varint,3,opt,name=variable,proto3" json:"variable,omitempty"`
-	Integer  int64   `protobuf:"varint,4,opt,name=integer,proto3" json:"integer,omitempty"`
-	Str      string  `protobuf:"bytes,5,opt,name=str,proto3" json:"str,omitempty"`
-	Date     uint64  `protobuf:"varint,6,opt,name=date,proto3" json:"date,omitempty"`
-	Bytes    []byte  `protobuf:"bytes,7,opt,name=bytes,proto3" json:"bytes,omitempty"`
-	Set      []*ID   `protobuf:"bytes,8,rep,name=set,proto3" json:"set,omitempty"`
+	Queries []*RuleV0 `protobuf:"bytes,1,rep,name=queries,proto3" json:"queries,omitempty"`
 }
 
-func (x *ID) Reset() {
-	*x = ID{}
+func (x *CaveatV0) Reset() {
+	*x = CaveatV0{}
 	if protoimpl.UnsafeEnabled {
 		mi := &file_biscuit_proto_msgTypes[8]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -924,13 +1328,13 @@ func (x *ID) Reset() {
 	}
 }
 
-func (x *ID) String() string {
+func (x *CaveatV0) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*ID) ProtoMessage() {}
+func (*CaveatV0) ProtoMessage() {}
 
-func (x *ID) ProtoReflect() protoreflect.Message {
+func (x *CaveatV0) ProtoReflect() protoreflect.Message {
 	mi := &file_biscuit_proto_msgTypes[8]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -942,83 +1346,28 @@ func (x *ID) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use ID.ProtoReflect.Descriptor instead.
-func (*ID) Descriptor() ([]byte, []int) {
+// Deprecated: Use CaveatV0.ProtoReflect.Descriptor instead.
+func (*CaveatV0) Descriptor() ([]byte, []int) {
 	return file_biscuit_proto_rawDescGZIP(), []int{8}
 }
 
-func (x *ID) GetKind() ID_Kind {
+func (x *CaveatV0) GetQueries() []*RuleV0 {
 	if x != nil {
-		return x.Kind
-	}
-	return ID_SYMBOL
-}
-
-func (x *ID) GetSymbol() uint64 {
-	if x != nil {
-		return x.Symbol
-	}
-	return 0
-}
-
-func (x *ID) GetVariable() uint32 {
-	if x != nil {
-		return x.Variable
-	}
-	return 0
-}
-
-func (x *ID) GetInteger() int64 {
-	if x != nil {
-		return x.Integer
-	}
-	return 0
-}
-
-func (x *ID) GetStr() string {
-	if x != nil {
-		return x.Str
-	}
-	return ""
-}
-
-func (x *ID) GetDate() uint64 {
-	if x != nil {
-		return x.Date
-	}
-	return 0
-}
-
-func (x *ID) GetBytes() []byte {
-	if x != nil {
-		return x.Bytes
+		return x.Queries
 	}
 	return nil
 }
 
-func (x *ID) GetSet() []*ID {
-	if x != nil {
-		return x.Set
-	}
-	return nil
-}
-
-type Constraint struct {
+type CaveatV1 struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id     uint32            `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
-	Kind   Constraint_Kind   `protobuf:"varint,2,opt,name=kind,proto3,enum=Constraint_Kind" json:"kind,omitempty"`
-	Int    *IntConstraint    `protobuf:"bytes,3,opt,name=int,proto3" json:"int,omitempty"`
-	Str    *StringConstraint `protobuf:"bytes,4,opt,name=str,proto3" json:"str,omitempty"`
-	Date   *DateConstraint   `protobuf:"bytes,5,opt,name=date,proto3" json:"date,omitempty"`
-	Symbol *SymbolConstraint `protobuf:"bytes,6,opt,name=symbol,proto3" json:"symbol,omitempty"`
-	Bytes  *BytesConstraint  `protobuf:"bytes,7,opt,name=bytes,proto3" json:"bytes,omitempty"`
+	Queries []*RuleV1 `protobuf:"bytes,1,rep,name=queries,proto3" json:"queries,omitempty"`
 }
 
-func (x *Constraint) Reset() {
-	*x = Constraint{}
+func (x *CaveatV1) Reset() {
+	*x = CaveatV1{}
 	if protoimpl.UnsafeEnabled {
 		mi := &file_biscuit_proto_msgTypes[9]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1026,13 +1375,13 @@ func (x *Constraint) Reset() {
 	}
 }
 
-func (x *Constraint) String() string {
+func (x *CaveatV1) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*Constraint) ProtoMessage() {}
+func (*CaveatV1) ProtoMessage() {}
 
-func (x *Constraint) ProtoReflect() protoreflect.Message {
+func (x *CaveatV1) ProtoReflect() protoreflect.Message {
 	mi := &file_biscuit_proto_msgTypes[9]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1044,77 +1393,29 @@ func (x *Constraint) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use Constraint.ProtoReflect.Descriptor instead.
-func (*Constraint) Descriptor() ([]byte, []int) {
+// Deprecated: Use CaveatV1.ProtoReflect.Descriptor instead.
+func (*CaveatV1) Descriptor() ([]byte, []int) {
 	return file_biscuit_proto_rawDescGZIP(), []int{9}
 }
 
-func (x *Constraint) GetId() uint32 {
+func (x *CaveatV1) GetQueries() []*RuleV1 {
 	if x != nil {
-		return x.Id
-	}
-	return 0
-}
-
-func (x *Constraint) GetKind() Constraint_Kind {
-	if x != nil {
-		return x.Kind
-	}
-	return Constraint_INT
-}
-
-func (x *Constraint) GetInt() *IntConstraint {
-	if x != nil {
-		return x.Int
+		return x.Queries
 	}
 	return nil
 }
 
-func (x *Constraint) GetStr() *StringConstraint {
-	if x != nil {
-		return x.Str
-	}
-	return nil
-}
-
-func (x *Constraint) GetDate() *DateConstraint {
-	if x != nil {
-		return x.Date
-	}
-	return nil
-}
-
-func (x *Constraint) GetSymbol() *SymbolConstraint {
-	if x != nil {
-		return x.Symbol
-	}
-	return nil
-}
-
-func (x *Constraint) GetBytes() *BytesConstraint {
-	if x != nil {
-		return x.Bytes
-	}
-	return nil
-}
-
-type IntConstraint struct {
+type PredicateV0 struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Kind          IntConstraint_Kind `protobuf:"varint,1,opt,name=kind,proto3,enum=IntConstraint_Kind" json:"kind,omitempty"`
-	Lower         int64              `protobuf:"varint,2,opt,name=lower,proto3" json:"lower,omitempty"`
-	Larger        int64              `protobuf:"varint,3,opt,name=larger,proto3" json:"larger,omitempty"`
-	LowerOrEqual  int64              `protobuf:"varint,4,opt,name=lower_or_equal,json=lowerOrEqual,proto3" json:"lower_or_equal,omitempty"`
-	LargerOrEqual int64              `protobuf:"varint,5,opt,name=larger_or_equal,json=largerOrEqual,proto3" json:"larger_or_equal,omitempty"`
-	Equal         int64              `protobuf:"varint,6,opt,name=equal,proto3" json:"equal,omitempty"`
-	InSet         []int64            `protobuf:"varint,7,rep,packed,name=in_set,json=inSet,proto3" json:"in_set,omitempty"`
-	NotInSet      []int64            `protobuf:"varint,8,rep,packed,name=not_in_set,json=notInSet,proto3" json:"not_in_set,omitempty"`
+	Name uint64  `protobuf:"varint,1,opt,name=name,proto3" json:"name,omitempty"`
+	Ids  []*IDV0 `protobuf:"bytes,2,rep,name=ids,proto3" json:"ids,omitempty"`
 }
 
-func (x *IntConstraint) Reset() {
-	*x = IntConstraint{}
+func (x *PredicateV0) Reset() {
+	*x = PredicateV0{}
 	if protoimpl.UnsafeEnabled {
 		mi := &file_biscuit_proto_msgTypes[10]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1122,13 +1423,13 @@ func (x *IntConstraint) Reset() {
 	}
 }
 
-func (x *IntConstraint) String() string {
+func (x *PredicateV0) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*IntConstraint) ProtoMessage() {}
+func (*PredicateV0) ProtoMessage() {}
 
-func (x *IntConstraint) ProtoReflect() protoreflect.Message {
+func (x *PredicateV0) ProtoReflect() protoreflect.Message {
 	mi := &file_biscuit_proto_msgTypes[10]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1140,83 +1441,36 @@ func (x *IntConstraint) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use IntConstraint.ProtoReflect.Descriptor instead.
-func (*IntConstraint) Descriptor() ([]byte, []int) {
+// Deprecated: Use PredicateV0.ProtoReflect.Descriptor instead.
+func (*PredicateV0) Descriptor() ([]byte, []int) {
 	return file_biscuit_proto_rawDescGZIP(), []int{10}
 }
 
-func (x *IntConstraint) GetKind() IntConstraint_Kind {
+func (x *PredicateV0) GetName() uint64 {
 	if x != nil {
-		return x.Kind
-	}
-	return IntConstraint_LOWER
-}
-
-func (x *IntConstraint) GetLower() int64 {
-	if x != nil {
-		return x.Lower
+		return x.Name
 	}
 	return 0
 }
 
-func (x *IntConstraint) GetLarger() int64 {
+func (x *PredicateV0) GetIds() []*IDV0 {
 	if x != nil {
-		return x.Larger
-	}
-	return 0
-}
-
-func (x *IntConstraint) GetLowerOrEqual() int64 {
-	if x != nil {
-		return x.LowerOrEqual
-	}
-	return 0
-}
-
-func (x *IntConstraint) GetLargerOrEqual() int64 {
-	if x != nil {
-		return x.LargerOrEqual
-	}
-	return 0
-}
-
-func (x *IntConstraint) GetEqual() int64 {
-	if x != nil {
-		return x.Equal
-	}
-	return 0
-}
-
-func (x *IntConstraint) GetInSet() []int64 {
-	if x != nil {
-		return x.InSet
+		return x.Ids
 	}
 	return nil
 }
 
-func (x *IntConstraint) GetNotInSet() []int64 {
-	if x != nil {
-		return x.NotInSet
-	}
-	return nil
-}
-
-type StringConstraint struct {
+type PredicateV1 struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Kind     StringConstraint_Kind `protobuf:"varint,1,opt,name=kind,proto3,enum=StringConstraint_Kind" json:"kind,omitempty"`
-	Prefix   string                `protobuf:"bytes,2,opt,name=prefix,proto3" json:"prefix,omitempty"`
-	Suffix   string                `protobuf:"bytes,3,opt,name=suffix,proto3" json:"suffix,omitempty"`
-	Equal    string                `protobuf:"bytes,4,opt,name=equal,proto3" json:"equal,omitempty"`
-	InSet    []string              `protobuf:"bytes,5,rep,name=in_set,json=inSet,proto3" json:"in_set,omitempty"`
-	NotInSet []string              `protobuf:"bytes,6,rep,name=not_in_set,json=notInSet,proto3" json:"not_in_set,omitempty"`
-	Regex    string                `protobuf:"bytes,7,opt,name=regex,proto3" json:"regex,omitempty"`
+	Name uint64  `protobuf:"varint,1,opt,name=name,proto3" json:"name,omitempty"`
+	Ids  []*IDV1 `protobuf:"bytes,2,rep,name=ids,proto3" json:"ids,omitempty"`
 }
 
-func (x *StringConstraint) Reset() {
-	*x = StringConstraint{}
+func (x *PredicateV1) Reset() {
+	*x = PredicateV1{}
 	if protoimpl.UnsafeEnabled {
 		mi := &file_biscuit_proto_msgTypes[11]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1224,13 +1478,13 @@ func (x *StringConstraint) Reset() {
 	}
 }
 
-func (x *StringConstraint) String() string {
+func (x *PredicateV1) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*StringConstraint) ProtoMessage() {}
+func (*PredicateV1) ProtoMessage() {}
 
-func (x *StringConstraint) ProtoReflect() protoreflect.Message {
+func (x *PredicateV1) ProtoReflect() protoreflect.Message {
 	mi := &file_biscuit_proto_msgTypes[11]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1242,72 +1496,42 @@ func (x *StringConstraint) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use StringConstraint.ProtoReflect.Descriptor instead.
-func (*StringConstraint) Descriptor() ([]byte, []int) {
+// Deprecated: Use PredicateV1.ProtoReflect.Descriptor instead.
+func (*PredicateV1) Descriptor() ([]byte, []int) {
 	return file_biscuit_proto_rawDescGZIP(), []int{11}
 }
 
-func (x *StringConstraint) GetKind() StringConstraint_Kind {
+func (x *PredicateV1) GetName() uint64 {
 	if x != nil {
-		return x.Kind
+		return x.Name
 	}
-	return StringConstraint_PREFIX
+	return 0
 }
 
-func (x *StringConstraint) GetPrefix() string {
+func (x *PredicateV1) GetIds() []*IDV1 {
 	if x != nil {
-		return x.Prefix
-	}
-	return ""
-}
-
-func (x *StringConstraint) GetSuffix() string {
-	if x != nil {
-		return x.Suffix
-	}
-	return ""
-}
-
-func (x *StringConstraint) GetEqual() string {
-	if x != nil {
-		return x.Equal
-	}
-	return ""
-}
-
-func (x *StringConstraint) GetInSet() []string {
-	if x != nil {
-		return x.InSet
+		return x.Ids
 	}
 	return nil
 }
 
-func (x *StringConstraint) GetNotInSet() []string {
-	if x != nil {
-		return x.NotInSet
-	}
-	return nil
-}
-
-func (x *StringConstraint) GetRegex() string {
-	if x != nil {
-		return x.Regex
-	}
-	return ""
-}
-
-type DateConstraint struct {
+type IDV0 struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Kind   DateConstraint_Kind `protobuf:"varint,1,opt,name=kind,proto3,enum=DateConstraint_Kind" json:"kind,omitempty"`
-	Before uint64              `protobuf:"varint,2,opt,name=before,proto3" json:"before,omitempty"`
-	After  uint64              `protobuf:"varint,3,opt,name=after,proto3" json:"after,omitempty"`
+	Kind     IDV0_Kind `protobuf:"varint,1,opt,name=kind,proto3,enum=IDV0_Kind" json:"kind,omitempty"`
+	Symbol   uint64    `protobuf:"varint,2,opt,name=symbol,proto3" json:"symbol,omitempty"`
+	Variable uint32    `protobuf:"varint,3,opt,name=variable,proto3" json:"variable,omitempty"`
+	Integer  int64     `protobuf:"varint,4,opt,name=integer,proto3" json:"integer,omitempty"`
+	Str      string    `protobuf:"bytes,5,opt,name=str,proto3" json:"str,omitempty"`
+	Date     uint64    `protobuf:"varint,6,opt,name=date,proto3" json:"date,omitempty"`
+	Bytes    []byte    `protobuf:"bytes,7,opt,name=bytes,proto3" json:"bytes,omitempty"`
+	Set      []*IDV0   `protobuf:"bytes,8,rep,name=set,proto3" json:"set,omitempty"`
 }
 
-func (x *DateConstraint) Reset() {
-	*x = DateConstraint{}
+func (x *IDV0) Reset() {
+	*x = IDV0{}
 	if protoimpl.UnsafeEnabled {
 		mi := &file_biscuit_proto_msgTypes[12]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1315,13 +1539,13 @@ func (x *DateConstraint) Reset() {
 	}
 }
 
-func (x *DateConstraint) String() string {
+func (x *IDV0) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*DateConstraint) ProtoMessage() {}
+func (*IDV0) ProtoMessage() {}
 
-func (x *DateConstraint) ProtoReflect() protoreflect.Message {
+func (x *IDV0) ProtoReflect() protoreflect.Message {
 	mi := &file_biscuit_proto_msgTypes[12]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1333,44 +1557,84 @@ func (x *DateConstraint) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use DateConstraint.ProtoReflect.Descriptor instead.
-func (*DateConstraint) Descriptor() ([]byte, []int) {
+// Deprecated: Use IDV0.ProtoReflect.Descriptor instead.
+func (*IDV0) Descriptor() ([]byte, []int) {
 	return file_biscuit_proto_rawDescGZIP(), []int{12}
 }
 
-func (x *DateConstraint) GetKind() DateConstraint_Kind {
+func (x *IDV0) GetKind() IDV0_Kind {
 	if x != nil {
 		return x.Kind
 	}
-	return DateConstraint_BEFORE
+	return IDV0_SYMBOL
 }
 
-func (x *DateConstraint) GetBefore() uint64 {
+func (x *IDV0) GetSymbol() uint64 {
 	if x != nil {
-		return x.Before
+		return x.Symbol
 	}
 	return 0
 }
 
-func (x *DateConstraint) GetAfter() uint64 {
+func (x *IDV0) GetVariable() uint32 {
 	if x != nil {
-		return x.After
+		return x.Variable
 	}
 	return 0
 }
 
-type SymbolConstraint struct {
+func (x *IDV0) GetInteger() int64 {
+	if x != nil {
+		return x.Integer
+	}
+	return 0
+}
+
+func (x *IDV0) GetStr() string {
+	if x != nil {
+		return x.Str
+	}
+	return ""
+}
+
+func (x *IDV0) GetDate() uint64 {
+	if x != nil {
+		return x.Date
+	}
+	return 0
+}
+
+func (x *IDV0) GetBytes() []byte {
+	if x != nil {
+		return x.Bytes
+	}
+	return nil
+}
+
+func (x *IDV0) GetSet() []*IDV0 {
+	if x != nil {
+		return x.Set
+	}
+	return nil
+}
+
+type IDV1 struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Kind     SymbolConstraint_Kind `protobuf:"varint,1,opt,name=kind,proto3,enum=SymbolConstraint_Kind" json:"kind,omitempty"`
-	InSet    []uint64              `protobuf:"varint,2,rep,packed,name=in_set,json=inSet,proto3" json:"in_set,omitempty"`
-	NotInSet []uint64              `protobuf:"varint,3,rep,packed,name=not_in_set,json=notInSet,proto3" json:"not_in_set,omitempty"`
+	Kind     IDV1_Kind `protobuf:"varint,1,opt,name=kind,proto3,enum=IDV1_Kind" json:"kind,omitempty"`
+	Symbol   uint64    `protobuf:"varint,2,opt,name=symbol,proto3" json:"symbol,omitempty"`
+	Variable uint32    `protobuf:"varint,3,opt,name=variable,proto3" json:"variable,omitempty"`
+	Integer  int64     `protobuf:"varint,4,opt,name=integer,proto3" json:"integer,omitempty"`
+	Str      string    `protobuf:"bytes,5,opt,name=str,proto3" json:"str,omitempty"`
+	Date     uint64    `protobuf:"varint,6,opt,name=date,proto3" json:"date,omitempty"`
+	Bytes    []byte    `protobuf:"bytes,7,opt,name=bytes,proto3" json:"bytes,omitempty"`
+	Set      []*IDV1   `protobuf:"bytes,8,rep,name=set,proto3" json:"set,omitempty"`
 }
 
-func (x *SymbolConstraint) Reset() {
-	*x = SymbolConstraint{}
+func (x *IDV1) Reset() {
+	*x = IDV1{}
 	if protoimpl.UnsafeEnabled {
 		mi := &file_biscuit_proto_msgTypes[13]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1378,13 +1642,13 @@ func (x *SymbolConstraint) Reset() {
 	}
 }
 
-func (x *SymbolConstraint) String() string {
+func (x *IDV1) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*SymbolConstraint) ProtoMessage() {}
+func (*IDV1) ProtoMessage() {}
 
-func (x *SymbolConstraint) ProtoReflect() protoreflect.Message {
+func (x *IDV1) ProtoReflect() protoreflect.Message {
 	mi := &file_biscuit_proto_msgTypes[13]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1396,45 +1660,83 @@ func (x *SymbolConstraint) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use SymbolConstraint.ProtoReflect.Descriptor instead.
-func (*SymbolConstraint) Descriptor() ([]byte, []int) {
+// Deprecated: Use IDV1.ProtoReflect.Descriptor instead.
+func (*IDV1) Descriptor() ([]byte, []int) {
 	return file_biscuit_proto_rawDescGZIP(), []int{13}
 }
 
-func (x *SymbolConstraint) GetKind() SymbolConstraint_Kind {
+func (x *IDV1) GetKind() IDV1_Kind {
 	if x != nil {
 		return x.Kind
 	}
-	return SymbolConstraint_IN
+	return IDV1_SYMBOL
 }
 
-func (x *SymbolConstraint) GetInSet() []uint64 {
+func (x *IDV1) GetSymbol() uint64 {
 	if x != nil {
-		return x.InSet
+		return x.Symbol
+	}
+	return 0
+}
+
+func (x *IDV1) GetVariable() uint32 {
+	if x != nil {
+		return x.Variable
+	}
+	return 0
+}
+
+func (x *IDV1) GetInteger() int64 {
+	if x != nil {
+		return x.Integer
+	}
+	return 0
+}
+
+func (x *IDV1) GetStr() string {
+	if x != nil {
+		return x.Str
+	}
+	return ""
+}
+
+func (x *IDV1) GetDate() uint64 {
+	if x != nil {
+		return x.Date
+	}
+	return 0
+}
+
+func (x *IDV1) GetBytes() []byte {
+	if x != nil {
+		return x.Bytes
 	}
 	return nil
 }
 
-func (x *SymbolConstraint) GetNotInSet() []uint64 {
+func (x *IDV1) GetSet() []*IDV1 {
 	if x != nil {
-		return x.NotInSet
+		return x.Set
 	}
 	return nil
 }
 
-type BytesConstraint struct {
+type ConstraintV0 struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Kind     BytesConstraint_Kind `protobuf:"varint,1,opt,name=kind,proto3,enum=BytesConstraint_Kind" json:"kind,omitempty"`
-	Equal    []byte               `protobuf:"bytes,2,opt,name=equal,proto3" json:"equal,omitempty"`
-	InSet    [][]byte             `protobuf:"bytes,3,rep,name=in_set,json=inSet,proto3" json:"in_set,omitempty"`
-	NotInSet [][]byte             `protobuf:"bytes,4,rep,name=not_in_set,json=notInSet,proto3" json:"not_in_set,omitempty"`
+	Id     uint32              `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	Kind   ConstraintV0_Kind   `protobuf:"varint,2,opt,name=kind,proto3,enum=ConstraintV0_Kind" json:"kind,omitempty"`
+	Int    *IntConstraintV0    `protobuf:"bytes,3,opt,name=int,proto3" json:"int,omitempty"`
+	Str    *StringConstraintV0 `protobuf:"bytes,4,opt,name=str,proto3" json:"str,omitempty"`
+	Date   *DateConstraintV0   `protobuf:"bytes,5,opt,name=date,proto3" json:"date,omitempty"`
+	Symbol *SymbolConstraintV0 `protobuf:"bytes,6,opt,name=symbol,proto3" json:"symbol,omitempty"`
+	Bytes  *BytesConstraintV0  `protobuf:"bytes,7,opt,name=bytes,proto3" json:"bytes,omitempty"`
 }
 
-func (x *BytesConstraint) Reset() {
-	*x = BytesConstraint{}
+func (x *ConstraintV0) Reset() {
+	*x = ConstraintV0{}
 	if protoimpl.UnsafeEnabled {
 		mi := &file_biscuit_proto_msgTypes[14]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1442,13 +1744,13 @@ func (x *BytesConstraint) Reset() {
 	}
 }
 
-func (x *BytesConstraint) String() string {
+func (x *ConstraintV0) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*BytesConstraint) ProtoMessage() {}
+func (*ConstraintV0) ProtoMessage() {}
 
-func (x *BytesConstraint) ProtoReflect() protoreflect.Message {
+func (x *ConstraintV0) ProtoReflect() protoreflect.Message {
 	mi := &file_biscuit_proto_msgTypes[14]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1460,33 +1762,939 @@ func (x *BytesConstraint) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use BytesConstraint.ProtoReflect.Descriptor instead.
-func (*BytesConstraint) Descriptor() ([]byte, []int) {
+// Deprecated: Use ConstraintV0.ProtoReflect.Descriptor instead.
+func (*ConstraintV0) Descriptor() ([]byte, []int) {
 	return file_biscuit_proto_rawDescGZIP(), []int{14}
 }
 
-func (x *BytesConstraint) GetKind() BytesConstraint_Kind {
+func (x *ConstraintV0) GetId() uint32 {
+	if x != nil {
+		return x.Id
+	}
+	return 0
+}
+
+func (x *ConstraintV0) GetKind() ConstraintV0_Kind {
 	if x != nil {
 		return x.Kind
 	}
-	return BytesConstraint_EQUAL
+	return ConstraintV0_INT
 }
 
-func (x *BytesConstraint) GetEqual() []byte {
+func (x *ConstraintV0) GetInt() *IntConstraintV0 {
 	if x != nil {
-		return x.Equal
+		return x.Int
 	}
 	return nil
 }
 
-func (x *BytesConstraint) GetInSet() [][]byte {
+func (x *ConstraintV0) GetStr() *StringConstraintV0 {
+	if x != nil {
+		return x.Str
+	}
+	return nil
+}
+
+func (x *ConstraintV0) GetDate() *DateConstraintV0 {
+	if x != nil {
+		return x.Date
+	}
+	return nil
+}
+
+func (x *ConstraintV0) GetSymbol() *SymbolConstraintV0 {
+	if x != nil {
+		return x.Symbol
+	}
+	return nil
+}
+
+func (x *ConstraintV0) GetBytes() *BytesConstraintV0 {
+	if x != nil {
+		return x.Bytes
+	}
+	return nil
+}
+
+type ConstraintV1 struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Id     uint32              `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	Kind   ConstraintV1_Kind   `protobuf:"varint,2,opt,name=kind,proto3,enum=ConstraintV1_Kind" json:"kind,omitempty"`
+	Int    *IntConstraintV1    `protobuf:"bytes,3,opt,name=int,proto3" json:"int,omitempty"`
+	Str    *StringConstraintV1 `protobuf:"bytes,4,opt,name=str,proto3" json:"str,omitempty"`
+	Date   *DateConstraintV1   `protobuf:"bytes,5,opt,name=date,proto3" json:"date,omitempty"`
+	Symbol *SymbolConstraintV1 `protobuf:"bytes,6,opt,name=symbol,proto3" json:"symbol,omitempty"`
+	Bytes  *BytesConstraintV1  `protobuf:"bytes,7,opt,name=bytes,proto3" json:"bytes,omitempty"`
+}
+
+func (x *ConstraintV1) Reset() {
+	*x = ConstraintV1{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_biscuit_proto_msgTypes[15]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *ConstraintV1) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ConstraintV1) ProtoMessage() {}
+
+func (x *ConstraintV1) ProtoReflect() protoreflect.Message {
+	mi := &file_biscuit_proto_msgTypes[15]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ConstraintV1.ProtoReflect.Descriptor instead.
+func (*ConstraintV1) Descriptor() ([]byte, []int) {
+	return file_biscuit_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *ConstraintV1) GetId() uint32 {
+	if x != nil {
+		return x.Id
+	}
+	return 0
+}
+
+func (x *ConstraintV1) GetKind() ConstraintV1_Kind {
+	if x != nil {
+		return x.Kind
+	}
+	return ConstraintV1_INT
+}
+
+func (x *ConstraintV1) GetInt() *IntConstraintV1 {
+	if x != nil {
+		return x.Int
+	}
+	return nil
+}
+
+func (x *ConstraintV1) GetStr() *StringConstraintV1 {
+	if x != nil {
+		return x.Str
+	}
+	return nil
+}
+
+func (x *ConstraintV1) GetDate() *DateConstraintV1 {
+	if x != nil {
+		return x.Date
+	}
+	return nil
+}
+
+func (x *ConstraintV1) GetSymbol() *SymbolConstraintV1 {
+	if x != nil {
+		return x.Symbol
+	}
+	return nil
+}
+
+func (x *ConstraintV1) GetBytes() *BytesConstraintV1 {
+	if x != nil {
+		return x.Bytes
+	}
+	return nil
+}
+
+type IntConstraintV0 struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Kind          IntConstraintV0_Kind `protobuf:"varint,1,opt,name=kind,proto3,enum=IntConstraintV0_Kind" json:"kind,omitempty"`
+	Lower         int64                `protobuf:"varint,2,opt,name=lower,proto3" json:"lower,omitempty"`
+	Larger        int64                `protobuf:"varint,3,opt,name=larger,proto3" json:"larger,omitempty"`
+	LowerOrEqual  int64                `protobuf:"varint,4,opt,name=lower_or_equal,json=lowerOrEqual,proto3" json:"lower_or_equal,omitempty"`
+	LargerOrEqual int64                `protobuf:"varint,5,opt,name=larger_or_equal,json=largerOrEqual,proto3" json:"larger_or_equal,omitempty"`
+	Equal         int64                `protobuf:"varint,6,opt,name=equal,proto3" json:"equal,omitempty"`
+	InSet         []int64              `protobuf:"varint,7,rep,packed,name=in_set,json=inSet,proto3" json:"in_set,omitempty"`
+	NotInSet      []int64              `protobuf:"varint,8,rep,packed,name=not_in_set,json=notInSet,proto3" json:"not_in_set,omitempty"`
+}
+
+func (x *IntConstraintV0) Reset() {
+	*x = IntConstraintV0{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_biscuit_proto_msgTypes[16]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *IntConstraintV0) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IntConstraintV0) ProtoMessage() {}
+
+func (x *IntConstraintV0) ProtoReflect() protoreflect.Message {
+	mi := &file_biscuit_proto_msgTypes[16]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use IntConstraintV0.ProtoReflect.Descriptor instead.
+func (*IntConstraintV0) Descriptor() ([]byte, []int) {
+	return file_biscuit_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *IntConstraintV0) GetKind() IntConstraintV0_Kind {
+	if x != nil {
+		return x.Kind
+	}
+	return IntConstraintV0_LOWER
+}
+
+func (x *IntConstraintV0) GetLower() int64 {
+	if x != nil {
+		return x.Lower
+	}
+	return 0
+}
+
+func (x *IntConstraintV0) GetLarger() int64 {
+	if x != nil {
+		return x.Larger
+	}
+	return 0
+}
+
+func (x *IntConstraintV0) GetLowerOrEqual() int64 {
+	if x != nil {
+		return x.LowerOrEqual
+	}
+	return 0
+}
+
+func (x *IntConstraintV0) GetLargerOrEqual() int64 {
+	if x != nil {
+		return x.LargerOrEqual
+	}
+	return 0
+}
+
+func (x *IntConstraintV0) GetEqual() int64 {
+	if x != nil {
+		return x.Equal
+	}
+	return 0
+}
+
+func (x *IntConstraintV0) GetInSet() []int64 {
 	if x != nil {
 		return x.InSet
 	}
 	return nil
 }
 
-func (x *BytesConstraint) GetNotInSet() [][]byte {
+func (x *IntConstraintV0) GetNotInSet() []int64 {
+	if x != nil {
+		return x.NotInSet
+	}
+	return nil
+}
+
+type IntConstraintV1 struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Kind          IntConstraintV1_Kind `protobuf:"varint,1,opt,name=kind,proto3,enum=IntConstraintV1_Kind" json:"kind,omitempty"`
+	Lower         int64                `protobuf:"varint,2,opt,name=lower,proto3" json:"lower,omitempty"`
+	Larger        int64                `protobuf:"varint,3,opt,name=larger,proto3" json:"larger,omitempty"`
+	LowerOrEqual  int64                `protobuf:"varint,4,opt,name=lower_or_equal,json=lowerOrEqual,proto3" json:"lower_or_equal,omitempty"`
+	LargerOrEqual int64                `protobuf:"varint,5,opt,name=larger_or_equal,json=largerOrEqual,proto3" json:"larger_or_equal,omitempty"`
+	Equal         int64                `protobuf:"varint,6,opt,name=equal,proto3" json:"equal,omitempty"`
+	InSet         []int64              `protobuf:"varint,7,rep,packed,name=in_set,json=inSet,proto3" json:"in_set,omitempty"`
+	NotInSet      []int64              `protobuf:"varint,8,rep,packed,name=not_in_set,json=notInSet,proto3" json:"not_in_set,omitempty"`
+}
+
+func (x *IntConstraintV1) Reset() {
+	*x = IntConstraintV1{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_biscuit_proto_msgTypes[17]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *IntConstraintV1) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IntConstraintV1) ProtoMessage() {}
+
+func (x *IntConstraintV1) ProtoReflect() protoreflect.Message {
+	mi := &file_biscuit_proto_msgTypes[17]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use IntConstraintV1.ProtoReflect.Descriptor instead.
+func (*IntConstraintV1) Descriptor() ([]byte, []int) {
+	return file_biscuit_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *IntConstraintV1) GetKind() IntConstraintV1_Kind {
+	if x != nil {
+		return x.Kind
+	}
+	return IntConstraintV1_LOWER
+}
+
+func (x *IntConstraintV1) GetLower() int64 {
+	if x != nil {
+		return x.Lower
+	}
+	return 0
+}
+
+func (x *IntConstraintV1) GetLarger() int64 {
+	if x != nil {
+		return x.Larger
+	}
+	return 0
+}
+
+func (x *IntConstraintV1) GetLowerOrEqual() int64 {
+	if x != nil {
+		return x.LowerOrEqual
+	}
+	return 0
+}
+
+func (x *IntConstraintV1) GetLargerOrEqual() int64 {
+	if x != nil {
+		return x.LargerOrEqual
+	}
+	return 0
+}
+
+func (x *IntConstraintV1) GetEqual() int64 {
+	if x != nil {
+		return x.Equal
+	}
+	return 0
+}
+
+func (x *IntConstraintV1) GetInSet() []int64 {
+	if x != nil {
+		return x.InSet
+	}
+	return nil
+}
+
+func (x *IntConstraintV1) GetNotInSet() []int64 {
+	if x != nil {
+		return x.NotInSet
+	}
+	return nil
+}
+
+type StringConstraintV0 struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Kind     StringConstraintV0_Kind `protobuf:"varint,1,opt,name=kind,proto3,enum=StringConstraintV0_Kind" json:"kind,omitempty"`
+	Prefix   string                  `protobuf:"bytes,2,opt,name=prefix,proto3" json:"prefix,omitempty"`
+	Suffix   string                  `protobuf:"bytes,3,opt,name=suffix,proto3" json:"suffix,omitempty"`
+	Equal    string                  `protobuf:"bytes,4,opt,name=equal,proto3" json:"equal,omitempty"`
+	InSet    []string                `protobuf:"bytes,5,rep,name=in_set,json=inSet,proto3" json:"in_set,omitempty"`
+	NotInSet []string                `protobuf:"bytes,6,rep,name=not_in_set,json=notInSet,proto3" json:"not_in_set,omitempty"`
+	Regex    string                  `protobuf:"bytes,7,opt,name=regex,proto3" json:"regex,omitempty"`
+}
+
+func (x *StringConstraintV0) Reset() {
+	*x = StringConstraintV0{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_biscuit_proto_msgTypes[18]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *StringConstraintV0) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StringConstraintV0) ProtoMessage() {}
+
+func (x *StringConstraintV0) ProtoReflect() protoreflect.Message {
+	mi := &file_biscuit_proto_msgTypes[18]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StringConstraintV0.ProtoReflect.Descriptor instead.
+func (*StringConstraintV0) Descriptor() ([]byte, []int) {
+	return file_biscuit_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *StringConstraintV0) GetKind() StringConstraintV0_Kind {
+	if x != nil {
+		return x.Kind
+	}
+	return StringConstraintV0_PREFIX
+}
+
+func (x *StringConstraintV0) GetPrefix() string {
+	if x != nil {
+		return x.Prefix
+	}
+	return ""
+}
+
+func (x *StringConstraintV0) GetSuffix() string {
+	if x != nil {
+		return x.Suffix
+	}
+	return ""
+}
+
+func (x *StringConstraintV0) GetEqual() string {
+	if x != nil {
+		return x.Equal
+	}
+	return ""
+}
+
+func (x *StringConstraintV0) GetInSet() []string {
+	if x != nil {
+		return x.InSet
+	}
+	return nil
+}
+
+func (x *StringConstraintV0) GetNotInSet() []string {
+	if x != nil {
+		return x.NotInSet
+	}
+	return nil
+}
+
+func (x *StringConstraintV0) GetRegex() string {
+	if x != nil {
+		return x.Regex
+	}
+	return ""
+}
+
+type StringConstraintV1 struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Kind     StringConstraintV1_Kind `protobuf:"varint,1,opt,name=kind,proto3,enum=StringConstraintV1_Kind" json:"kind,omitempty"`
+	Prefix   string                  `protobuf:"bytes,2,opt,name=prefix,proto3" json:"prefix,omitempty"`
+	Suffix   string                  `protobuf:"bytes,3,opt,name=suffix,proto3" json:"suffix,omitempty"`
+	Equal    string                  `protobuf:"bytes,4,opt,name=equal,proto3" json:"equal,omitempty"`
+	InSet    []string                `protobuf:"bytes,5,rep,name=in_set,json=inSet,proto3" json:"in_set,omitempty"`
+	NotInSet []string                `protobuf:"bytes,6,rep,name=not_in_set,json=notInSet,proto3" json:"not_in_set,omitempty"`
+	Regex    string                  `protobuf:"bytes,7,opt,name=regex,proto3" json:"regex,omitempty"`
+}
+
+func (x *StringConstraintV1) Reset() {
+	*x = StringConstraintV1{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_biscuit_proto_msgTypes[19]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *StringConstraintV1) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StringConstraintV1) ProtoMessage() {}
+
+func (x *StringConstraintV1) ProtoReflect() protoreflect.Message {
+	mi := &file_biscuit_proto_msgTypes[19]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StringConstraintV1.ProtoReflect.Descriptor instead.
+func (*StringConstraintV1) Descriptor() ([]byte, []int) {
+	return file_biscuit_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *StringConstraintV1) GetKind() StringConstraintV1_Kind {
+	if x != nil {
+		return x.Kind
+	}
+	return StringConstraintV1_PREFIX
+}
+
+func (x *StringConstraintV1) GetPrefix() string {
+	if x != nil {
+		return x.Prefix
+	}
+	return ""
+}
+
+func (x *StringConstraintV1) GetSuffix() string {
+	if x != nil {
+		return x.Suffix
+	}
+	return ""
+}
+
+func (x *StringConstraintV1) GetEqual() string {
+	if x != nil {
+		return x.Equal
+	}
+	return ""
+}
+
+func (x *StringConstraintV1) GetInSet() []string {
+	if x != nil {
+		return x.InSet
+	}
+	return nil
+}
+
+func (x *StringConstraintV1) GetNotInSet() []string {
+	if x != nil {
+		return x.NotInSet
+	}
+	return nil
+}
+
+func (x *StringConstraintV1) GetRegex() string {
+	if x != nil {
+		return x.Regex
+	}
+	return ""
+}
+
+type DateConstraintV0 struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Kind   DateConstraintV0_Kind `protobuf:"varint,1,opt,name=kind,proto3,enum=DateConstraintV0_Kind" json:"kind,omitempty"`
+	Before uint64                `protobuf:"varint,2,opt,name=before,proto3" json:"before,omitempty"`
+	After  uint64                `protobuf:"varint,3,opt,name=after,proto3" json:"after,omitempty"`
+}
+
+func (x *DateConstraintV0) Reset() {
+	*x = DateConstraintV0{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_biscuit_proto_msgTypes[20]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *DateConstraintV0) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DateConstraintV0) ProtoMessage() {}
+
+func (x *DateConstraintV0) ProtoReflect() protoreflect.Message {
+	mi := &file_biscuit_proto_msgTypes[20]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DateConstraintV0.ProtoReflect.Descriptor instead.
+func (*DateConstraintV0) Descriptor() ([]byte, []int) {
+	return file_biscuit_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *DateConstraintV0) GetKind() DateConstraintV0_Kind {
+	if x != nil {
+		return x.Kind
+	}
+	return DateConstraintV0_BEFORE
+}
+
+func (x *DateConstraintV0) GetBefore() uint64 {
+	if x != nil {
+		return x.Before
+	}
+	return 0
+}
+
+func (x *DateConstraintV0) GetAfter() uint64 {
+	if x != nil {
+		return x.After
+	}
+	return 0
+}
+
+type DateConstraintV1 struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Kind   DateConstraintV1_Kind `protobuf:"varint,1,opt,name=kind,proto3,enum=DateConstraintV1_Kind" json:"kind,omitempty"`
+	Before uint64                `protobuf:"varint,2,opt,name=before,proto3" json:"before,omitempty"`
+	After  uint64                `protobuf:"varint,3,opt,name=after,proto3" json:"after,omitempty"`
+}
+
+func (x *DateConstraintV1) Reset() {
+	*x = DateConstraintV1{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_biscuit_proto_msgTypes[21]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *DateConstraintV1) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DateConstraintV1) ProtoMessage() {}
+
+func (x *DateConstraintV1) ProtoReflect() protoreflect.Message {
+	mi := &file_biscuit_proto_msgTypes[21]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DateConstraintV1.ProtoReflect.Descriptor instead.
+func (*DateConstraintV1) Descriptor() ([]byte, []int) {
+	return file_biscuit_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *DateConstraintV1) GetKind() DateConstraintV1_Kind {
+	if x != nil {
+		return x.Kind
+	}
+	return DateConstraintV1_BEFORE
+}
+
+func (x *DateConstraintV1) GetBefore() uint64 {
+	if x != nil {
+		return x.Before
+	}
+	return 0
+}
+
+func (x *DateConstraintV1) GetAfter() uint64 {
+	if x != nil {
+		return x.After
+	}
+	return 0
+}
+
+type SymbolConstraintV0 struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Kind     SymbolConstraintV0_Kind `protobuf:"varint,1,opt,name=kind,proto3,enum=SymbolConstraintV0_Kind" json:"kind,omitempty"`
+	InSet    []uint64                `protobuf:"varint,2,rep,packed,name=in_set,json=inSet,proto3" json:"in_set,omitempty"`
+	NotInSet []uint64                `protobuf:"varint,3,rep,packed,name=not_in_set,json=notInSet,proto3" json:"not_in_set,omitempty"`
+}
+
+func (x *SymbolConstraintV0) Reset() {
+	*x = SymbolConstraintV0{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_biscuit_proto_msgTypes[22]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *SymbolConstraintV0) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SymbolConstraintV0) ProtoMessage() {}
+
+func (x *SymbolConstraintV0) ProtoReflect() protoreflect.Message {
+	mi := &file_biscuit_proto_msgTypes[22]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SymbolConstraintV0.ProtoReflect.Descriptor instead.
+func (*SymbolConstraintV0) Descriptor() ([]byte, []int) {
+	return file_biscuit_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *SymbolConstraintV0) GetKind() SymbolConstraintV0_Kind {
+	if x != nil {
+		return x.Kind
+	}
+	return SymbolConstraintV0_IN
+}
+
+func (x *SymbolConstraintV0) GetInSet() []uint64 {
+	if x != nil {
+		return x.InSet
+	}
+	return nil
+}
+
+func (x *SymbolConstraintV0) GetNotInSet() []uint64 {
+	if x != nil {
+		return x.NotInSet
+	}
+	return nil
+}
+
+type SymbolConstraintV1 struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Kind     SymbolConstraintV1_Kind `protobuf:"varint,1,opt,name=kind,proto3,enum=SymbolConstraintV1_Kind" json:"kind,omitempty"`
+	InSet    []uint64                `protobuf:"varint,2,rep,packed,name=in_set,json=inSet,proto3" json:"in_set,omitempty"`
+	NotInSet []uint64                `protobuf:"varint,3,rep,packed,name=not_in_set,json=notInSet,proto3" json:"not_in_set,omitempty"`
+}
+
+func (x *SymbolConstraintV1) Reset() {
+	*x = SymbolConstraintV1{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_biscuit_proto_msgTypes[23]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *SymbolConstraintV1) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SymbolConstraintV1) ProtoMessage() {}
+
+func (x *SymbolConstraintV1) ProtoReflect() protoreflect.Message {
+	mi := &file_biscuit_proto_msgTypes[23]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SymbolConstraintV1.ProtoReflect.Descriptor instead.
+func (*SymbolConstraintV1) Descriptor() ([]byte, []int) {
+	return file_biscuit_proto_rawDescGZIP(), []int{23}
+}
+
+func (x *SymbolConstraintV1) GetKind() SymbolConstraintV1_Kind {
+	if x != nil {
+		return x.Kind
+	}
+	return SymbolConstraintV1_IN
+}
+
+func (x *SymbolConstraintV1) GetInSet() []uint64 {
+	if x != nil {
+		return x.InSet
+	}
+	return nil
+}
+
+func (x *SymbolConstraintV1) GetNotInSet() []uint64 {
+	if x != nil {
+		return x.NotInSet
+	}
+	return nil
+}
+
+type BytesConstraintV0 struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Kind     BytesConstraintV0_Kind `protobuf:"varint,1,opt,name=kind,proto3,enum=BytesConstraintV0_Kind" json:"kind,omitempty"`
+	Equal    []byte                 `protobuf:"bytes,2,opt,name=equal,proto3" json:"equal,omitempty"`
+	InSet    [][]byte               `protobuf:"bytes,3,rep,name=in_set,json=inSet,proto3" json:"in_set,omitempty"`
+	NotInSet [][]byte               `protobuf:"bytes,4,rep,name=not_in_set,json=notInSet,proto3" json:"not_in_set,omitempty"`
+}
+
+func (x *BytesConstraintV0) Reset() {
+	*x = BytesConstraintV0{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_biscuit_proto_msgTypes[24]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *BytesConstraintV0) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BytesConstraintV0) ProtoMessage() {}
+
+func (x *BytesConstraintV0) ProtoReflect() protoreflect.Message {
+	mi := &file_biscuit_proto_msgTypes[24]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BytesConstraintV0.ProtoReflect.Descriptor instead.
+func (*BytesConstraintV0) Descriptor() ([]byte, []int) {
+	return file_biscuit_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *BytesConstraintV0) GetKind() BytesConstraintV0_Kind {
+	if x != nil {
+		return x.Kind
+	}
+	return BytesConstraintV0_EQUAL
+}
+
+func (x *BytesConstraintV0) GetEqual() []byte {
+	if x != nil {
+		return x.Equal
+	}
+	return nil
+}
+
+func (x *BytesConstraintV0) GetInSet() [][]byte {
+	if x != nil {
+		return x.InSet
+	}
+	return nil
+}
+
+func (x *BytesConstraintV0) GetNotInSet() [][]byte {
+	if x != nil {
+		return x.NotInSet
+	}
+	return nil
+}
+
+type BytesConstraintV1 struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Kind     BytesConstraintV1_Kind `protobuf:"varint,1,opt,name=kind,proto3,enum=BytesConstraintV1_Kind" json:"kind,omitempty"`
+	Equal    []byte                 `protobuf:"bytes,2,opt,name=equal,proto3" json:"equal,omitempty"`
+	InSet    [][]byte               `protobuf:"bytes,3,rep,name=in_set,json=inSet,proto3" json:"in_set,omitempty"`
+	NotInSet [][]byte               `protobuf:"bytes,4,rep,name=not_in_set,json=notInSet,proto3" json:"not_in_set,omitempty"`
+}
+
+func (x *BytesConstraintV1) Reset() {
+	*x = BytesConstraintV1{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_biscuit_proto_msgTypes[25]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *BytesConstraintV1) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BytesConstraintV1) ProtoMessage() {}
+
+func (x *BytesConstraintV1) ProtoReflect() protoreflect.Message {
+	mi := &file_biscuit_proto_msgTypes[25]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BytesConstraintV1.ProtoReflect.Descriptor instead.
+func (*BytesConstraintV1) Descriptor() ([]byte, []int) {
+	return file_biscuit_proto_rawDescGZIP(), []int{25}
+}
+
+func (x *BytesConstraintV1) GetKind() BytesConstraintV1_Kind {
+	if x != nil {
+		return x.Kind
+	}
+	return BytesConstraintV1_EQUAL
+}
+
+func (x *BytesConstraintV1) GetEqual() []byte {
+	if x != nil {
+		return x.Equal
+	}
+	return nil
+}
+
+func (x *BytesConstraintV1) GetInSet() [][]byte {
+	if x != nil {
+		return x.InSet
+	}
+	return nil
+}
+
+func (x *BytesConstraintV1) GetNotInSet() [][]byte {
 	if x != nil {
 		return x.NotInSet
 	}
@@ -1514,146 +2722,287 @@ var file_biscuit_proto_rawDesc = []byte{
 	0x75, 0x72, 0x65, 0x22, 0x39, 0x0a, 0x09, 0x53, 0x69, 0x67, 0x6e, 0x61, 0x74, 0x75, 0x72, 0x65,
 	0x12, 0x1e, 0x0a, 0x0a, 0x70, 0x61, 0x72, 0x61, 0x6d, 0x65, 0x74, 0x65, 0x72, 0x73, 0x18, 0x01,
 	0x20, 0x03, 0x28, 0x0c, 0x52, 0x0a, 0x70, 0x61, 0x72, 0x61, 0x6d, 0x65, 0x74, 0x65, 0x72, 0x73,
-	0x12, 0x0c, 0x0a, 0x01, 0x7a, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0c, 0x52, 0x01, 0x7a, 0x22, 0xc8,
-	0x01, 0x0a, 0x05, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x12, 0x14, 0x0a, 0x05, 0x69, 0x6e, 0x64, 0x65,
+	0x12, 0x0c, 0x0a, 0x01, 0x7a, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0c, 0x52, 0x01, 0x7a, 0x22, 0xcf,
+	0x02, 0x0a, 0x05, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x12, 0x14, 0x0a, 0x05, 0x69, 0x6e, 0x64, 0x65,
 	0x78, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0d, 0x52, 0x05, 0x69, 0x6e, 0x64, 0x65, 0x78, 0x12, 0x18,
 	0x0a, 0x07, 0x73, 0x79, 0x6d, 0x62, 0x6f, 0x6c, 0x73, 0x18, 0x02, 0x20, 0x03, 0x28, 0x09, 0x52,
-	0x07, 0x73, 0x79, 0x6d, 0x62, 0x6f, 0x6c, 0x73, 0x12, 0x1b, 0x0a, 0x05, 0x66, 0x61, 0x63, 0x74,
-	0x73, 0x18, 0x03, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x05, 0x2e, 0x46, 0x61, 0x63, 0x74, 0x52, 0x05,
-	0x66, 0x61, 0x63, 0x74, 0x73, 0x12, 0x1b, 0x0a, 0x05, 0x72, 0x75, 0x6c, 0x65, 0x73, 0x18, 0x04,
-	0x20, 0x03, 0x28, 0x0b, 0x32, 0x05, 0x2e, 0x52, 0x75, 0x6c, 0x65, 0x52, 0x05, 0x72, 0x75, 0x6c,
-	0x65, 0x73, 0x12, 0x21, 0x0a, 0x07, 0x63, 0x61, 0x76, 0x65, 0x61, 0x74, 0x73, 0x18, 0x05, 0x20,
-	0x03, 0x28, 0x0b, 0x32, 0x07, 0x2e, 0x43, 0x61, 0x76, 0x65, 0x61, 0x74, 0x52, 0x07, 0x63, 0x61,
-	0x76, 0x65, 0x61, 0x74, 0x73, 0x12, 0x18, 0x0a, 0x07, 0x63, 0x6f, 0x6e, 0x74, 0x65, 0x78, 0x74,
-	0x18, 0x06, 0x20, 0x01, 0x28, 0x09, 0x52, 0x07, 0x63, 0x6f, 0x6e, 0x74, 0x65, 0x78, 0x74, 0x12,
-	0x18, 0x0a, 0x07, 0x76, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x18, 0x07, 0x20, 0x01, 0x28, 0x0d,
-	0x52, 0x07, 0x76, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x22, 0x30, 0x0a, 0x04, 0x46, 0x61, 0x63,
-	0x74, 0x12, 0x28, 0x0a, 0x09, 0x70, 0x72, 0x65, 0x64, 0x69, 0x63, 0x61, 0x74, 0x65, 0x18, 0x01,
-	0x20, 0x01, 0x28, 0x0b, 0x32, 0x0a, 0x2e, 0x50, 0x72, 0x65, 0x64, 0x69, 0x63, 0x61, 0x74, 0x65,
-	0x52, 0x09, 0x70, 0x72, 0x65, 0x64, 0x69, 0x63, 0x61, 0x74, 0x65, 0x22, 0x75, 0x0a, 0x04, 0x52,
-	0x75, 0x6c, 0x65, 0x12, 0x1e, 0x0a, 0x04, 0x68, 0x65, 0x61, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28,
-	0x0b, 0x32, 0x0a, 0x2e, 0x50, 0x72, 0x65, 0x64, 0x69, 0x63, 0x61, 0x74, 0x65, 0x52, 0x04, 0x68,
-	0x65, 0x61, 0x64, 0x12, 0x1e, 0x0a, 0x04, 0x62, 0x6f, 0x64, 0x79, 0x18, 0x02, 0x20, 0x03, 0x28,
-	0x0b, 0x32, 0x0a, 0x2e, 0x50, 0x72, 0x65, 0x64, 0x69, 0x63, 0x61, 0x74, 0x65, 0x52, 0x04, 0x62,
-	0x6f, 0x64, 0x79, 0x12, 0x2d, 0x0a, 0x0b, 0x63, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e,
-	0x74, 0x73, 0x18, 0x03, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x0b, 0x2e, 0x43, 0x6f, 0x6e, 0x73, 0x74,
-	0x72, 0x61, 0x69, 0x6e, 0x74, 0x52, 0x0b, 0x63, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e,
-	0x74, 0x73, 0x22, 0x29, 0x0a, 0x06, 0x43, 0x61, 0x76, 0x65, 0x61, 0x74, 0x12, 0x1f, 0x0a, 0x07,
-	0x71, 0x75, 0x65, 0x72, 0x69, 0x65, 0x73, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x05, 0x2e,
-	0x52, 0x75, 0x6c, 0x65, 0x52, 0x07, 0x71, 0x75, 0x65, 0x72, 0x69, 0x65, 0x73, 0x22, 0x36, 0x0a,
-	0x09, 0x50, 0x72, 0x65, 0x64, 0x69, 0x63, 0x61, 0x74, 0x65, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61,
-	0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x04, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x15,
-	0x0a, 0x03, 0x69, 0x64, 0x73, 0x18, 0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x03, 0x2e, 0x49, 0x44,
-	0x52, 0x03, 0x69, 0x64, 0x73, 0x22, 0x99, 0x02, 0x0a, 0x02, 0x49, 0x44, 0x12, 0x1c, 0x0a, 0x04,
-	0x6b, 0x69, 0x6e, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x08, 0x2e, 0x49, 0x44, 0x2e,
-	0x4b, 0x69, 0x6e, 0x64, 0x52, 0x04, 0x6b, 0x69, 0x6e, 0x64, 0x12, 0x16, 0x0a, 0x06, 0x73, 0x79,
-	0x6d, 0x62, 0x6f, 0x6c, 0x18, 0x02, 0x20, 0x01, 0x28, 0x04, 0x52, 0x06, 0x73, 0x79, 0x6d, 0x62,
-	0x6f, 0x6c, 0x12, 0x1a, 0x0a, 0x08, 0x76, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x18, 0x03,
-	0x20, 0x01, 0x28, 0x0d, 0x52, 0x08, 0x76, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x12, 0x18,
-	0x0a, 0x07, 0x69, 0x6e, 0x74, 0x65, 0x67, 0x65, 0x72, 0x18, 0x04, 0x20, 0x01, 0x28, 0x03, 0x52,
-	0x07, 0x69, 0x6e, 0x74, 0x65, 0x67, 0x65, 0x72, 0x12, 0x10, 0x0a, 0x03, 0x73, 0x74, 0x72, 0x18,
-	0x05, 0x20, 0x01, 0x28, 0x09, 0x52, 0x03, 0x73, 0x74, 0x72, 0x12, 0x12, 0x0a, 0x04, 0x64, 0x61,
-	0x74, 0x65, 0x18, 0x06, 0x20, 0x01, 0x28, 0x04, 0x52, 0x04, 0x64, 0x61, 0x74, 0x65, 0x12, 0x14,
-	0x0a, 0x05, 0x62, 0x79, 0x74, 0x65, 0x73, 0x18, 0x07, 0x20, 0x01, 0x28, 0x0c, 0x52, 0x05, 0x62,
-	0x79, 0x74, 0x65, 0x73, 0x12, 0x15, 0x0a, 0x03, 0x73, 0x65, 0x74, 0x18, 0x08, 0x20, 0x03, 0x28,
-	0x0b, 0x32, 0x03, 0x2e, 0x49, 0x44, 0x52, 0x03, 0x73, 0x65, 0x74, 0x22, 0x54, 0x0a, 0x04, 0x4b,
-	0x69, 0x6e, 0x64, 0x12, 0x0a, 0x0a, 0x06, 0x53, 0x59, 0x4d, 0x42, 0x4f, 0x4c, 0x10, 0x00, 0x12,
-	0x0c, 0x0a, 0x08, 0x56, 0x41, 0x52, 0x49, 0x41, 0x42, 0x4c, 0x45, 0x10, 0x01, 0x12, 0x0b, 0x0a,
-	0x07, 0x49, 0x4e, 0x54, 0x45, 0x47, 0x45, 0x52, 0x10, 0x02, 0x12, 0x07, 0x0a, 0x03, 0x53, 0x54,
-	0x52, 0x10, 0x03, 0x12, 0x08, 0x0a, 0x04, 0x44, 0x41, 0x54, 0x45, 0x10, 0x04, 0x12, 0x09, 0x0a,
-	0x05, 0x42, 0x59, 0x54, 0x45, 0x53, 0x10, 0x05, 0x12, 0x07, 0x0a, 0x03, 0x53, 0x45, 0x54, 0x10,
-	0x06, 0x22, 0xc8, 0x02, 0x0a, 0x0a, 0x43, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74,
-	0x12, 0x0e, 0x0a, 0x02, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0d, 0x52, 0x02, 0x69, 0x64,
-	0x12, 0x24, 0x0a, 0x04, 0x6b, 0x69, 0x6e, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x10,
-	0x2e, 0x43, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74, 0x2e, 0x4b, 0x69, 0x6e, 0x64,
-	0x52, 0x04, 0x6b, 0x69, 0x6e, 0x64, 0x12, 0x20, 0x0a, 0x03, 0x69, 0x6e, 0x74, 0x18, 0x03, 0x20,
-	0x01, 0x28, 0x0b, 0x32, 0x0e, 0x2e, 0x49, 0x6e, 0x74, 0x43, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61,
-	0x69, 0x6e, 0x74, 0x52, 0x03, 0x69, 0x6e, 0x74, 0x12, 0x23, 0x0a, 0x03, 0x73, 0x74, 0x72, 0x18,
-	0x04, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x11, 0x2e, 0x53, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x43, 0x6f,
-	0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74, 0x52, 0x03, 0x73, 0x74, 0x72, 0x12, 0x23, 0x0a,
-	0x04, 0x64, 0x61, 0x74, 0x65, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x0f, 0x2e, 0x44, 0x61,
-	0x74, 0x65, 0x43, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74, 0x52, 0x04, 0x64, 0x61,
-	0x74, 0x65, 0x12, 0x29, 0x0a, 0x06, 0x73, 0x79, 0x6d, 0x62, 0x6f, 0x6c, 0x18, 0x06, 0x20, 0x01,
-	0x28, 0x0b, 0x32, 0x11, 0x2e, 0x53, 0x79, 0x6d, 0x62, 0x6f, 0x6c, 0x43, 0x6f, 0x6e, 0x73, 0x74,
-	0x72, 0x61, 0x69, 0x6e, 0x74, 0x52, 0x06, 0x73, 0x79, 0x6d, 0x62, 0x6f, 0x6c, 0x12, 0x26, 0x0a,
-	0x05, 0x62, 0x79, 0x74, 0x65, 0x73, 0x18, 0x07, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x10, 0x2e, 0x42,
-	0x79, 0x74, 0x65, 0x73, 0x43, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74, 0x52, 0x05,
-	0x62, 0x79, 0x74, 0x65, 0x73, 0x22, 0x45, 0x0a, 0x04, 0x4b, 0x69, 0x6e, 0x64, 0x12, 0x07, 0x0a,
-	0x03, 0x49, 0x4e, 0x54, 0x10, 0x00, 0x12, 0x0a, 0x0a, 0x06, 0x53, 0x54, 0x52, 0x49, 0x4e, 0x47,
-	0x10, 0x01, 0x12, 0x08, 0x0a, 0x04, 0x44, 0x41, 0x54, 0x45, 0x10, 0x02, 0x12, 0x0a, 0x0a, 0x06,
-	0x53, 0x59, 0x4d, 0x42, 0x4f, 0x4c, 0x10, 0x03, 0x12, 0x09, 0x0a, 0x05, 0x42, 0x59, 0x54, 0x45,
-	0x53, 0x10, 0x04, 0x12, 0x07, 0x0a, 0x03, 0x53, 0x45, 0x54, 0x10, 0x05, 0x22, 0xee, 0x02, 0x0a,
-	0x0d, 0x49, 0x6e, 0x74, 0x43, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74, 0x12, 0x27,
-	0x0a, 0x04, 0x6b, 0x69, 0x6e, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x13, 0x2e, 0x49,
-	0x6e, 0x74, 0x43, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74, 0x2e, 0x4b, 0x69, 0x6e,
-	0x64, 0x52, 0x04, 0x6b, 0x69, 0x6e, 0x64, 0x12, 0x14, 0x0a, 0x05, 0x6c, 0x6f, 0x77, 0x65, 0x72,
-	0x18, 0x02, 0x20, 0x01, 0x28, 0x03, 0x52, 0x05, 0x6c, 0x6f, 0x77, 0x65, 0x72, 0x12, 0x16, 0x0a,
-	0x06, 0x6c, 0x61, 0x72, 0x67, 0x65, 0x72, 0x18, 0x03, 0x20, 0x01, 0x28, 0x03, 0x52, 0x06, 0x6c,
-	0x61, 0x72, 0x67, 0x65, 0x72, 0x12, 0x24, 0x0a, 0x0e, 0x6c, 0x6f, 0x77, 0x65, 0x72, 0x5f, 0x6f,
-	0x72, 0x5f, 0x65, 0x71, 0x75, 0x61, 0x6c, 0x18, 0x04, 0x20, 0x01, 0x28, 0x03, 0x52, 0x0c, 0x6c,
-	0x6f, 0x77, 0x65, 0x72, 0x4f, 0x72, 0x45, 0x71, 0x75, 0x61, 0x6c, 0x12, 0x26, 0x0a, 0x0f, 0x6c,
-	0x61, 0x72, 0x67, 0x65, 0x72, 0x5f, 0x6f, 0x72, 0x5f, 0x65, 0x71, 0x75, 0x61, 0x6c, 0x18, 0x05,
-	0x20, 0x01, 0x28, 0x03, 0x52, 0x0d, 0x6c, 0x61, 0x72, 0x67, 0x65, 0x72, 0x4f, 0x72, 0x45, 0x71,
-	0x75, 0x61, 0x6c, 0x12, 0x14, 0x0a, 0x05, 0x65, 0x71, 0x75, 0x61, 0x6c, 0x18, 0x06, 0x20, 0x01,
-	0x28, 0x03, 0x52, 0x05, 0x65, 0x71, 0x75, 0x61, 0x6c, 0x12, 0x19, 0x0a, 0x06, 0x69, 0x6e, 0x5f,
-	0x73, 0x65, 0x74, 0x18, 0x07, 0x20, 0x03, 0x28, 0x03, 0x42, 0x02, 0x10, 0x01, 0x52, 0x05, 0x69,
-	0x6e, 0x53, 0x65, 0x74, 0x12, 0x20, 0x0a, 0x0a, 0x6e, 0x6f, 0x74, 0x5f, 0x69, 0x6e, 0x5f, 0x73,
-	0x65, 0x74, 0x18, 0x08, 0x20, 0x03, 0x28, 0x03, 0x42, 0x02, 0x10, 0x01, 0x52, 0x08, 0x6e, 0x6f,
-	0x74, 0x49, 0x6e, 0x53, 0x65, 0x74, 0x22, 0x65, 0x0a, 0x04, 0x4b, 0x69, 0x6e, 0x64, 0x12, 0x09,
-	0x0a, 0x05, 0x4c, 0x4f, 0x57, 0x45, 0x52, 0x10, 0x00, 0x12, 0x0a, 0x0a, 0x06, 0x4c, 0x41, 0x52,
-	0x47, 0x45, 0x52, 0x10, 0x01, 0x12, 0x12, 0x0a, 0x0e, 0x4c, 0x4f, 0x57, 0x45, 0x52, 0x5f, 0x4f,
-	0x52, 0x5f, 0x45, 0x51, 0x55, 0x41, 0x4c, 0x10, 0x02, 0x12, 0x13, 0x0a, 0x0f, 0x4c, 0x41, 0x52,
-	0x47, 0x45, 0x52, 0x5f, 0x4f, 0x52, 0x5f, 0x45, 0x51, 0x55, 0x41, 0x4c, 0x10, 0x03, 0x12, 0x09,
-	0x0a, 0x05, 0x45, 0x51, 0x55, 0x41, 0x4c, 0x10, 0x04, 0x12, 0x06, 0x0a, 0x02, 0x49, 0x4e, 0x10,
-	0x05, 0x12, 0x0a, 0x0a, 0x06, 0x4e, 0x4f, 0x54, 0x5f, 0x49, 0x4e, 0x10, 0x06, 0x22, 0x99, 0x02,
-	0x0a, 0x10, 0x53, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x43, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61, 0x69,
-	0x6e, 0x74, 0x12, 0x2a, 0x0a, 0x04, 0x6b, 0x69, 0x6e, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0e,
-	0x32, 0x16, 0x2e, 0x53, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x43, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61,
-	0x69, 0x6e, 0x74, 0x2e, 0x4b, 0x69, 0x6e, 0x64, 0x52, 0x04, 0x6b, 0x69, 0x6e, 0x64, 0x12, 0x16,
-	0x0a, 0x06, 0x70, 0x72, 0x65, 0x66, 0x69, 0x78, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x06,
-	0x70, 0x72, 0x65, 0x66, 0x69, 0x78, 0x12, 0x16, 0x0a, 0x06, 0x73, 0x75, 0x66, 0x66, 0x69, 0x78,
-	0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x06, 0x73, 0x75, 0x66, 0x66, 0x69, 0x78, 0x12, 0x14,
-	0x0a, 0x05, 0x65, 0x71, 0x75, 0x61, 0x6c, 0x18, 0x04, 0x20, 0x01, 0x28, 0x09, 0x52, 0x05, 0x65,
-	0x71, 0x75, 0x61, 0x6c, 0x12, 0x15, 0x0a, 0x06, 0x69, 0x6e, 0x5f, 0x73, 0x65, 0x74, 0x18, 0x05,
-	0x20, 0x03, 0x28, 0x09, 0x52, 0x05, 0x69, 0x6e, 0x53, 0x65, 0x74, 0x12, 0x1c, 0x0a, 0x0a, 0x6e,
-	0x6f, 0x74, 0x5f, 0x69, 0x6e, 0x5f, 0x73, 0x65, 0x74, 0x18, 0x06, 0x20, 0x03, 0x28, 0x09, 0x52,
-	0x08, 0x6e, 0x6f, 0x74, 0x49, 0x6e, 0x53, 0x65, 0x74, 0x12, 0x14, 0x0a, 0x05, 0x72, 0x65, 0x67,
-	0x65, 0x78, 0x18, 0x07, 0x20, 0x01, 0x28, 0x09, 0x52, 0x05, 0x72, 0x65, 0x67, 0x65, 0x78, 0x22,
-	0x48, 0x0a, 0x04, 0x4b, 0x69, 0x6e, 0x64, 0x12, 0x0a, 0x0a, 0x06, 0x50, 0x52, 0x45, 0x46, 0x49,
-	0x58, 0x10, 0x00, 0x12, 0x0a, 0x0a, 0x06, 0x53, 0x55, 0x46, 0x46, 0x49, 0x58, 0x10, 0x01, 0x12,
-	0x09, 0x0a, 0x05, 0x45, 0x51, 0x55, 0x41, 0x4c, 0x10, 0x02, 0x12, 0x06, 0x0a, 0x02, 0x49, 0x4e,
-	0x10, 0x03, 0x12, 0x0a, 0x0a, 0x06, 0x4e, 0x4f, 0x54, 0x5f, 0x49, 0x4e, 0x10, 0x04, 0x12, 0x09,
-	0x0a, 0x05, 0x52, 0x45, 0x47, 0x45, 0x58, 0x10, 0x05, 0x22, 0x87, 0x01, 0x0a, 0x0e, 0x44, 0x61,
-	0x74, 0x65, 0x43, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74, 0x12, 0x28, 0x0a, 0x04,
-	0x6b, 0x69, 0x6e, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x14, 0x2e, 0x44, 0x61, 0x74,
-	0x65, 0x43, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74, 0x2e, 0x4b, 0x69, 0x6e, 0x64,
-	0x52, 0x04, 0x6b, 0x69, 0x6e, 0x64, 0x12, 0x16, 0x0a, 0x06, 0x62, 0x65, 0x66, 0x6f, 0x72, 0x65,
-	0x18, 0x02, 0x20, 0x01, 0x28, 0x04, 0x52, 0x06, 0x62, 0x65, 0x66, 0x6f, 0x72, 0x65, 0x12, 0x14,
-	0x0a, 0x05, 0x61, 0x66, 0x74, 0x65, 0x72, 0x18, 0x03, 0x20, 0x01, 0x28, 0x04, 0x52, 0x05, 0x61,
-	0x66, 0x74, 0x65, 0x72, 0x22, 0x1d, 0x0a, 0x04, 0x4b, 0x69, 0x6e, 0x64, 0x12, 0x0a, 0x0a, 0x06,
-	0x42, 0x45, 0x46, 0x4f, 0x52, 0x45, 0x10, 0x00, 0x12, 0x09, 0x0a, 0x05, 0x41, 0x46, 0x54, 0x45,
-	0x52, 0x10, 0x01, 0x22, 0x8f, 0x01, 0x0a, 0x10, 0x53, 0x79, 0x6d, 0x62, 0x6f, 0x6c, 0x43, 0x6f,
-	0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74, 0x12, 0x2a, 0x0a, 0x04, 0x6b, 0x69, 0x6e, 0x64,
-	0x18, 0x01, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x16, 0x2e, 0x53, 0x79, 0x6d, 0x62, 0x6f, 0x6c, 0x43,
-	0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74, 0x2e, 0x4b, 0x69, 0x6e, 0x64, 0x52, 0x04,
-	0x6b, 0x69, 0x6e, 0x64, 0x12, 0x15, 0x0a, 0x06, 0x69, 0x6e, 0x5f, 0x73, 0x65, 0x74, 0x18, 0x02,
-	0x20, 0x03, 0x28, 0x04, 0x52, 0x05, 0x69, 0x6e, 0x53, 0x65, 0x74, 0x12, 0x1c, 0x0a, 0x0a, 0x6e,
-	0x6f, 0x74, 0x5f, 0x69, 0x6e, 0x5f, 0x73, 0x65, 0x74, 0x18, 0x03, 0x20, 0x03, 0x28, 0x04, 0x52,
-	0x08, 0x6e, 0x6f, 0x74, 0x49, 0x6e, 0x53, 0x65, 0x74, 0x22, 0x1a, 0x0a, 0x04, 0x4b, 0x69, 0x6e,
-	0x64, 0x12, 0x06, 0x0a, 0x02, 0x49, 0x4e, 0x10, 0x00, 0x12, 0x0a, 0x0a, 0x06, 0x4e, 0x4f, 0x54,
-	0x5f, 0x49, 0x4e, 0x10, 0x01, 0x22, 0xae, 0x01, 0x0a, 0x0f, 0x42, 0x79, 0x74, 0x65, 0x73, 0x43,
-	0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74, 0x12, 0x29, 0x0a, 0x04, 0x6b, 0x69, 0x6e,
-	0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x15, 0x2e, 0x42, 0x79, 0x74, 0x65, 0x73, 0x43,
-	0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74, 0x2e, 0x4b, 0x69, 0x6e, 0x64, 0x52, 0x04,
-	0x6b, 0x69, 0x6e, 0x64, 0x12, 0x14, 0x0a, 0x05, 0x65, 0x71, 0x75, 0x61, 0x6c, 0x18, 0x02, 0x20,
-	0x01, 0x28, 0x0c, 0x52, 0x05, 0x65, 0x71, 0x75, 0x61, 0x6c, 0x12, 0x15, 0x0a, 0x06, 0x69, 0x6e,
-	0x5f, 0x73, 0x65, 0x74, 0x18, 0x03, 0x20, 0x03, 0x28, 0x0c, 0x52, 0x05, 0x69, 0x6e, 0x53, 0x65,
-	0x74, 0x12, 0x1c, 0x0a, 0x0a, 0x6e, 0x6f, 0x74, 0x5f, 0x69, 0x6e, 0x5f, 0x73, 0x65, 0x74, 0x18,
-	0x04, 0x20, 0x03, 0x28, 0x0c, 0x52, 0x08, 0x6e, 0x6f, 0x74, 0x49, 0x6e, 0x53, 0x65, 0x74, 0x22,
-	0x25, 0x0a, 0x04, 0x4b, 0x69, 0x6e, 0x64, 0x12, 0x09, 0x0a, 0x05, 0x45, 0x51, 0x55, 0x41, 0x4c,
-	0x10, 0x00, 0x12, 0x06, 0x0a, 0x02, 0x49, 0x4e, 0x10, 0x01, 0x12, 0x0a, 0x0a, 0x06, 0x4e, 0x4f,
-	0x54, 0x5f, 0x49, 0x4e, 0x10, 0x02, 0x42, 0x06, 0x5a, 0x04, 0x2e, 0x3b, 0x70, 0x62, 0x62, 0x06,
-	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x07, 0x73, 0x79, 0x6d, 0x62, 0x6f, 0x6c, 0x73, 0x12, 0x22, 0x0a, 0x08, 0x66, 0x61, 0x63, 0x74,
+	0x73, 0x5f, 0x76, 0x30, 0x18, 0x03, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x07, 0x2e, 0x46, 0x61, 0x63,
+	0x74, 0x56, 0x30, 0x52, 0x07, 0x66, 0x61, 0x63, 0x74, 0x73, 0x56, 0x30, 0x12, 0x22, 0x0a, 0x08,
+	0x72, 0x75, 0x6c, 0x65, 0x73, 0x5f, 0x76, 0x30, 0x18, 0x04, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x07,
+	0x2e, 0x52, 0x75, 0x6c, 0x65, 0x56, 0x30, 0x52, 0x07, 0x72, 0x75, 0x6c, 0x65, 0x73, 0x56, 0x30,
+	0x12, 0x28, 0x0a, 0x0a, 0x63, 0x61, 0x76, 0x65, 0x61, 0x74, 0x73, 0x5f, 0x76, 0x30, 0x18, 0x05,
+	0x20, 0x03, 0x28, 0x0b, 0x32, 0x09, 0x2e, 0x43, 0x61, 0x76, 0x65, 0x61, 0x74, 0x56, 0x30, 0x52,
+	0x09, 0x63, 0x61, 0x76, 0x65, 0x61, 0x74, 0x73, 0x56, 0x30, 0x12, 0x18, 0x0a, 0x07, 0x63, 0x6f,
+	0x6e, 0x74, 0x65, 0x78, 0x74, 0x18, 0x06, 0x20, 0x01, 0x28, 0x09, 0x52, 0x07, 0x63, 0x6f, 0x6e,
+	0x74, 0x65, 0x78, 0x74, 0x12, 0x18, 0x0a, 0x07, 0x76, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x18,
+	0x07, 0x20, 0x01, 0x28, 0x0d, 0x52, 0x07, 0x76, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x12, 0x22,
+	0x0a, 0x08, 0x66, 0x61, 0x63, 0x74, 0x73, 0x5f, 0x76, 0x31, 0x18, 0x08, 0x20, 0x03, 0x28, 0x0b,
+	0x32, 0x07, 0x2e, 0x46, 0x61, 0x63, 0x74, 0x56, 0x31, 0x52, 0x07, 0x66, 0x61, 0x63, 0x74, 0x73,
+	0x56, 0x31, 0x12, 0x22, 0x0a, 0x08, 0x72, 0x75, 0x6c, 0x65, 0x73, 0x5f, 0x76, 0x31, 0x18, 0x09,
+	0x20, 0x03, 0x28, 0x0b, 0x32, 0x07, 0x2e, 0x52, 0x75, 0x6c, 0x65, 0x56, 0x31, 0x52, 0x07, 0x72,
+	0x75, 0x6c, 0x65, 0x73, 0x56, 0x31, 0x12, 0x28, 0x0a, 0x0a, 0x63, 0x61, 0x76, 0x65, 0x61, 0x74,
+	0x73, 0x5f, 0x76, 0x31, 0x18, 0x0a, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x09, 0x2e, 0x43, 0x61, 0x76,
+	0x65, 0x61, 0x74, 0x56, 0x31, 0x52, 0x09, 0x63, 0x61, 0x76, 0x65, 0x61, 0x74, 0x73, 0x56, 0x31,
+	0x22, 0x34, 0x0a, 0x06, 0x46, 0x61, 0x63, 0x74, 0x56, 0x30, 0x12, 0x2a, 0x0a, 0x09, 0x70, 0x72,
+	0x65, 0x64, 0x69, 0x63, 0x61, 0x74, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x0c, 0x2e,
+	0x50, 0x72, 0x65, 0x64, 0x69, 0x63, 0x61, 0x74, 0x65, 0x56, 0x30, 0x52, 0x09, 0x70, 0x72, 0x65,
+	0x64, 0x69, 0x63, 0x61, 0x74, 0x65, 0x22, 0x34, 0x0a, 0x06, 0x46, 0x61, 0x63, 0x74, 0x56, 0x31,
+	0x12, 0x2a, 0x0a, 0x09, 0x70, 0x72, 0x65, 0x64, 0x69, 0x63, 0x61, 0x74, 0x65, 0x18, 0x01, 0x20,
+	0x01, 0x28, 0x0b, 0x32, 0x0c, 0x2e, 0x50, 0x72, 0x65, 0x64, 0x69, 0x63, 0x61, 0x74, 0x65, 0x56,
+	0x31, 0x52, 0x09, 0x70, 0x72, 0x65, 0x64, 0x69, 0x63, 0x61, 0x74, 0x65, 0x22, 0x7d, 0x0a, 0x06,
+	0x52, 0x75, 0x6c, 0x65, 0x56, 0x30, 0x12, 0x20, 0x0a, 0x04, 0x68, 0x65, 0x61, 0x64, 0x18, 0x01,
+	0x20, 0x01, 0x28, 0x0b, 0x32, 0x0c, 0x2e, 0x50, 0x72, 0x65, 0x64, 0x69, 0x63, 0x61, 0x74, 0x65,
+	0x56, 0x30, 0x52, 0x04, 0x68, 0x65, 0x61, 0x64, 0x12, 0x20, 0x0a, 0x04, 0x62, 0x6f, 0x64, 0x79,
+	0x18, 0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x0c, 0x2e, 0x50, 0x72, 0x65, 0x64, 0x69, 0x63, 0x61,
+	0x74, 0x65, 0x56, 0x30, 0x52, 0x04, 0x62, 0x6f, 0x64, 0x79, 0x12, 0x2f, 0x0a, 0x0b, 0x63, 0x6f,
+	0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74, 0x73, 0x18, 0x03, 0x20, 0x03, 0x28, 0x0b, 0x32,
+	0x0d, 0x2e, 0x43, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74, 0x56, 0x30, 0x52, 0x0b,
+	0x63, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74, 0x73, 0x22, 0x7d, 0x0a, 0x06, 0x52,
+	0x75, 0x6c, 0x65, 0x56, 0x31, 0x12, 0x20, 0x0a, 0x04, 0x68, 0x65, 0x61, 0x64, 0x18, 0x01, 0x20,
+	0x01, 0x28, 0x0b, 0x32, 0x0c, 0x2e, 0x50, 0x72, 0x65, 0x64, 0x69, 0x63, 0x61, 0x74, 0x65, 0x56,
+	0x31, 0x52, 0x04, 0x68, 0x65, 0x61, 0x64, 0x12, 0x20, 0x0a, 0x04, 0x62, 0x6f, 0x64, 0x79, 0x18,
+	0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x0c, 0x2e, 0x50, 0x72, 0x65, 0x64, 0x69, 0x63, 0x61, 0x74,
+	0x65, 0x56, 0x31, 0x52, 0x04, 0x62, 0x6f, 0x64, 0x79, 0x12, 0x2f, 0x0a, 0x0b, 0x63, 0x6f, 0x6e,
+	0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74, 0x73, 0x18, 0x03, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x0d,
+	0x2e, 0x43, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74, 0x56, 0x31, 0x52, 0x0b, 0x63,
+	0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74, 0x73, 0x22, 0x2d, 0x0a, 0x08, 0x43, 0x61,
+	0x76, 0x65, 0x61, 0x74, 0x56, 0x30, 0x12, 0x21, 0x0a, 0x07, 0x71, 0x75, 0x65, 0x72, 0x69, 0x65,
+	0x73, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x07, 0x2e, 0x52, 0x75, 0x6c, 0x65, 0x56, 0x30,
+	0x52, 0x07, 0x71, 0x75, 0x65, 0x72, 0x69, 0x65, 0x73, 0x22, 0x2d, 0x0a, 0x08, 0x43, 0x61, 0x76,
+	0x65, 0x61, 0x74, 0x56, 0x31, 0x12, 0x21, 0x0a, 0x07, 0x71, 0x75, 0x65, 0x72, 0x69, 0x65, 0x73,
+	0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x07, 0x2e, 0x52, 0x75, 0x6c, 0x65, 0x56, 0x31, 0x52,
+	0x07, 0x71, 0x75, 0x65, 0x72, 0x69, 0x65, 0x73, 0x22, 0x3a, 0x0a, 0x0b, 0x50, 0x72, 0x65, 0x64,
+	0x69, 0x63, 0x61, 0x74, 0x65, 0x56, 0x30, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18,
+	0x01, 0x20, 0x01, 0x28, 0x04, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x17, 0x0a, 0x03, 0x69,
+	0x64, 0x73, 0x18, 0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x05, 0x2e, 0x49, 0x44, 0x56, 0x30, 0x52,
+	0x03, 0x69, 0x64, 0x73, 0x22, 0x3a, 0x0a, 0x0b, 0x50, 0x72, 0x65, 0x64, 0x69, 0x63, 0x61, 0x74,
+	0x65, 0x56, 0x31, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28,
+	0x04, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x17, 0x0a, 0x03, 0x69, 0x64, 0x73, 0x18, 0x02,
+	0x20, 0x03, 0x28, 0x0b, 0x32, 0x05, 0x2e, 0x49, 0x44, 0x56, 0x31, 0x52, 0x03, 0x69, 0x64, 0x73,
+	0x22, 0x9f, 0x02, 0x0a, 0x04, 0x49, 0x44, 0x56, 0x30, 0x12, 0x1e, 0x0a, 0x04, 0x6b, 0x69, 0x6e,
+	0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x0a, 0x2e, 0x49, 0x44, 0x56, 0x30, 0x2e, 0x4b,
+	0x69, 0x6e, 0x64, 0x52, 0x04, 0x6b, 0x69, 0x6e, 0x64, 0x12, 0x16, 0x0a, 0x06, 0x73, 0x79, 0x6d,
+	0x62, 0x6f, 0x6c, 0x18, 0x02, 0x20, 0x01, 0x28, 0x04, 0x52, 0x06, 0x73, 0x79, 0x6d, 0x62, 0x6f,
+	0x6c, 0x12, 0x1a, 0x0a, 0x08, 0x76, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x18, 0x03, 0x20,
+	0x01, 0x28, 0x0d, 0x52, 0x08, 0x76, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x12, 0x18, 0x0a,
+	0x07, 0x69, 0x6e, 0x74, 0x65, 0x67, 0x65, 0x72, 0x18, 0x04, 0x20, 0x01, 0x28, 0x03, 0x52, 0x07,
+	0x69, 0x6e, 0x74, 0x65, 0x67, 0x65, 0x72, 0x12, 0x10, 0x0a, 0x03, 0x73, 0x74, 0x72, 0x18, 0x05,
+	0x20, 0x01, 0x28, 0x09, 0x52, 0x03, 0x73, 0x74, 0x72, 0x12, 0x12, 0x0a, 0x04, 0x64, 0x61, 0x74,
+	0x65, 0x18, 0x06, 0x20, 0x01, 0x28, 0x04, 0x52, 0x04, 0x64, 0x61, 0x74, 0x65, 0x12, 0x14, 0x0a,
+	0x05, 0x62, 0x79, 0x74, 0x65, 0x73, 0x18, 0x07, 0x20, 0x01, 0x28, 0x0c, 0x52, 0x05, 0x62, 0x79,
+	0x74, 0x65, 0x73, 0x12, 0x17, 0x0a, 0x03, 0x73, 0x65, 0x74, 0x18, 0x08, 0x20, 0x03, 0x28, 0x0b,
+	0x32, 0x05, 0x2e, 0x49, 0x44, 0x56, 0x30, 0x52, 0x03, 0x73, 0x65, 0x74, 0x22, 0x54, 0x0a, 0x04,
+	0x4b, 0x69, 0x6e, 0x64, 0x12, 0x0a, 0x0a, 0x06, 0x53, 0x59, 0x4d, 0x42, 0x4f, 0x4c, 0x10, 0x00,
+	0x12, 0x0c, 0x0a, 0x08, 0x56, 0x41, 0x52, 0x49, 0x41, 0x42, 0x4c, 0x45, 0x10, 0x01, 0x12, 0x0b,
+	0x0a, 0x07, 0x49, 0x4e, 0x54, 0x45, 0x47, 0x45, 0x52, 0x10, 0x02, 0x12, 0x07, 0x0a, 0x03, 0x53,
+	0x54, 0x52, 0x10, 0x03, 0x12, 0x08, 0x0a, 0x04, 0x44, 0x41, 0x54, 0x45, 0x10, 0x04, 0x12, 0x09,
+	0x0a, 0x05, 0x42, 0x59, 0x54, 0x45, 0x53, 0x10, 0x05, 0x12, 0x07, 0x0a, 0x03, 0x53, 0x45, 0x54,
+	0x10, 0x06, 0x22, 0x9f, 0x02, 0x0a, 0x04, 0x49, 0x44, 0x56, 0x31, 0x12, 0x1e, 0x0a, 0x04, 0x6b,
+	0x69, 0x6e, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x0a, 0x2e, 0x49, 0x44, 0x56, 0x31,
+	0x2e, 0x4b, 0x69, 0x6e, 0x64, 0x52, 0x04, 0x6b, 0x69, 0x6e, 0x64, 0x12, 0x16, 0x0a, 0x06, 0x73,
+	0x79, 0x6d, 0x62, 0x6f, 0x6c, 0x18, 0x02, 0x20, 0x01, 0x28, 0x04, 0x52, 0x06, 0x73, 0x79, 0x6d,
+	0x62, 0x6f, 0x6c, 0x12, 0x1a, 0x0a, 0x08, 0x76, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x18,
+	0x03, 0x20, 0x01, 0x28, 0x0d, 0x52, 0x08, 0x76, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x12,
+	0x18, 0x0a, 0x07, 0x69, 0x6e, 0x74, 0x65, 0x67, 0x65, 0x72, 0x18, 0x04, 0x20, 0x01, 0x28, 0x03,
+	0x52, 0x07, 0x69, 0x6e, 0x74, 0x65, 0x67, 0x65, 0x72, 0x12, 0x10, 0x0a, 0x03, 0x73, 0x74, 0x72,
+	0x18, 0x05, 0x20, 0x01, 0x28, 0x09, 0x52, 0x03, 0x73, 0x74, 0x72, 0x12, 0x12, 0x0a, 0x04, 0x64,
+	0x61, 0x74, 0x65, 0x18, 0x06, 0x20, 0x01, 0x28, 0x04, 0x52, 0x04, 0x64, 0x61, 0x74, 0x65, 0x12,
+	0x14, 0x0a, 0x05, 0x62, 0x79, 0x74, 0x65, 0x73, 0x18, 0x07, 0x20, 0x01, 0x28, 0x0c, 0x52, 0x05,
+	0x62, 0x79, 0x74, 0x65, 0x73, 0x12, 0x17, 0x0a, 0x03, 0x73, 0x65, 0x74, 0x18, 0x08, 0x20, 0x03,
+	0x28, 0x0b, 0x32, 0x05, 0x2e, 0x49, 0x44, 0x56, 0x31, 0x52, 0x03, 0x73, 0x65, 0x74, 0x22, 0x54,
+	0x0a, 0x04, 0x4b, 0x69, 0x6e, 0x64, 0x12, 0x0a, 0x0a, 0x06, 0x53, 0x59, 0x4d, 0x42, 0x4f, 0x4c,
+	0x10, 0x00, 0x12, 0x0c, 0x0a, 0x08, 0x56, 0x41, 0x52, 0x49, 0x41, 0x42, 0x4c, 0x45, 0x10, 0x01,
+	0x12, 0x0b, 0x0a, 0x07, 0x49, 0x4e, 0x54, 0x45, 0x47, 0x45, 0x52, 0x10, 0x02, 0x12, 0x07, 0x0a,
+	0x03, 0x53, 0x54, 0x52, 0x10, 0x03, 0x12, 0x08, 0x0a, 0x04, 0x44, 0x41, 0x54, 0x45, 0x10, 0x04,
+	0x12, 0x09, 0x0a, 0x05, 0x42, 0x59, 0x54, 0x45, 0x53, 0x10, 0x05, 0x12, 0x07, 0x0a, 0x03, 0x53,
+	0x45, 0x54, 0x10, 0x06, 0x22, 0xd6, 0x02, 0x0a, 0x0c, 0x43, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61,
+	0x69, 0x6e, 0x74, 0x56, 0x30, 0x12, 0x0e, 0x0a, 0x02, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28,
+	0x0d, 0x52, 0x02, 0x69, 0x64, 0x12, 0x26, 0x0a, 0x04, 0x6b, 0x69, 0x6e, 0x64, 0x18, 0x02, 0x20,
+	0x01, 0x28, 0x0e, 0x32, 0x12, 0x2e, 0x43, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74,
+	0x56, 0x30, 0x2e, 0x4b, 0x69, 0x6e, 0x64, 0x52, 0x04, 0x6b, 0x69, 0x6e, 0x64, 0x12, 0x22, 0x0a,
+	0x03, 0x69, 0x6e, 0x74, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x10, 0x2e, 0x49, 0x6e, 0x74,
+	0x43, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74, 0x56, 0x30, 0x52, 0x03, 0x69, 0x6e,
+	0x74, 0x12, 0x25, 0x0a, 0x03, 0x73, 0x74, 0x72, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x13,
+	0x2e, 0x53, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x43, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e,
+	0x74, 0x56, 0x30, 0x52, 0x03, 0x73, 0x74, 0x72, 0x12, 0x25, 0x0a, 0x04, 0x64, 0x61, 0x74, 0x65,
+	0x18, 0x05, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x11, 0x2e, 0x44, 0x61, 0x74, 0x65, 0x43, 0x6f, 0x6e,
+	0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74, 0x56, 0x30, 0x52, 0x04, 0x64, 0x61, 0x74, 0x65, 0x12,
+	0x2b, 0x0a, 0x06, 0x73, 0x79, 0x6d, 0x62, 0x6f, 0x6c, 0x18, 0x06, 0x20, 0x01, 0x28, 0x0b, 0x32,
+	0x13, 0x2e, 0x53, 0x79, 0x6d, 0x62, 0x6f, 0x6c, 0x43, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61, 0x69,
+	0x6e, 0x74, 0x56, 0x30, 0x52, 0x06, 0x73, 0x79, 0x6d, 0x62, 0x6f, 0x6c, 0x12, 0x28, 0x0a, 0x05,
+	0x62, 0x79, 0x74, 0x65, 0x73, 0x18, 0x07, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x12, 0x2e, 0x42, 0x79,
+	0x74, 0x65, 0x73, 0x43, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74, 0x56, 0x30, 0x52,
+	0x05, 0x62, 0x79, 0x74, 0x65, 0x73, 0x22, 0x45, 0x0a, 0x04, 0x4b, 0x69, 0x6e, 0x64, 0x12, 0x07,
+	0x0a, 0x03, 0x49, 0x4e, 0x54, 0x10, 0x00, 0x12, 0x0a, 0x0a, 0x06, 0x53, 0x54, 0x52, 0x49, 0x4e,
+	0x47, 0x10, 0x01, 0x12, 0x08, 0x0a, 0x04, 0x44, 0x41, 0x54, 0x45, 0x10, 0x02, 0x12, 0x0a, 0x0a,
+	0x06, 0x53, 0x59, 0x4d, 0x42, 0x4f, 0x4c, 0x10, 0x03, 0x12, 0x09, 0x0a, 0x05, 0x42, 0x59, 0x54,
+	0x45, 0x53, 0x10, 0x04, 0x12, 0x07, 0x0a, 0x03, 0x53, 0x45, 0x54, 0x10, 0x05, 0x22, 0xd6, 0x02,
+	0x0a, 0x0c, 0x43, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74, 0x56, 0x31, 0x12, 0x0e,
+	0x0a, 0x02, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0d, 0x52, 0x02, 0x69, 0x64, 0x12, 0x26,
+	0x0a, 0x04, 0x6b, 0x69, 0x6e, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x12, 0x2e, 0x43,
+	0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74, 0x56, 0x31, 0x2e, 0x4b, 0x69, 0x6e, 0x64,
+	0x52, 0x04, 0x6b, 0x69, 0x6e, 0x64, 0x12, 0x22, 0x0a, 0x03, 0x69, 0x6e, 0x74, 0x18, 0x03, 0x20,
+	0x01, 0x28, 0x0b, 0x32, 0x10, 0x2e, 0x49, 0x6e, 0x74, 0x43, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61,
+	0x69, 0x6e, 0x74, 0x56, 0x31, 0x52, 0x03, 0x69, 0x6e, 0x74, 0x12, 0x25, 0x0a, 0x03, 0x73, 0x74,
+	0x72, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x13, 0x2e, 0x53, 0x74, 0x72, 0x69, 0x6e, 0x67,
+	0x43, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74, 0x56, 0x31, 0x52, 0x03, 0x73, 0x74,
+	0x72, 0x12, 0x25, 0x0a, 0x04, 0x64, 0x61, 0x74, 0x65, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0b, 0x32,
+	0x11, 0x2e, 0x44, 0x61, 0x74, 0x65, 0x43, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74,
+	0x56, 0x31, 0x52, 0x04, 0x64, 0x61, 0x74, 0x65, 0x12, 0x2b, 0x0a, 0x06, 0x73, 0x79, 0x6d, 0x62,
+	0x6f, 0x6c, 0x18, 0x06, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x13, 0x2e, 0x53, 0x79, 0x6d, 0x62, 0x6f,
+	0x6c, 0x43, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74, 0x56, 0x31, 0x52, 0x06, 0x73,
+	0x79, 0x6d, 0x62, 0x6f, 0x6c, 0x12, 0x28, 0x0a, 0x05, 0x62, 0x79, 0x74, 0x65, 0x73, 0x18, 0x07,
+	0x20, 0x01, 0x28, 0x0b, 0x32, 0x12, 0x2e, 0x42, 0x79, 0x74, 0x65, 0x73, 0x43, 0x6f, 0x6e, 0x73,
+	0x74, 0x72, 0x61, 0x69, 0x6e, 0x74, 0x56, 0x31, 0x52, 0x05, 0x62, 0x79, 0x74, 0x65, 0x73, 0x22,
+	0x45, 0x0a, 0x04, 0x4b, 0x69, 0x6e, 0x64, 0x12, 0x07, 0x0a, 0x03, 0x49, 0x4e, 0x54, 0x10, 0x00,
+	0x12, 0x0a, 0x0a, 0x06, 0x53, 0x54, 0x52, 0x49, 0x4e, 0x47, 0x10, 0x01, 0x12, 0x08, 0x0a, 0x04,
+	0x44, 0x41, 0x54, 0x45, 0x10, 0x02, 0x12, 0x0a, 0x0a, 0x06, 0x53, 0x59, 0x4d, 0x42, 0x4f, 0x4c,
+	0x10, 0x03, 0x12, 0x09, 0x0a, 0x05, 0x42, 0x59, 0x54, 0x45, 0x53, 0x10, 0x04, 0x12, 0x07, 0x0a,
+	0x03, 0x53, 0x45, 0x54, 0x10, 0x05, 0x22, 0xf2, 0x02, 0x0a, 0x0f, 0x49, 0x6e, 0x74, 0x43, 0x6f,
+	0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74, 0x56, 0x30, 0x12, 0x29, 0x0a, 0x04, 0x6b, 0x69,
+	0x6e, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x15, 0x2e, 0x49, 0x6e, 0x74, 0x43, 0x6f,
+	0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74, 0x56, 0x30, 0x2e, 0x4b, 0x69, 0x6e, 0x64, 0x52,
+	0x04, 0x6b, 0x69, 0x6e, 0x64, 0x12, 0x14, 0x0a, 0x05, 0x6c, 0x6f, 0x77, 0x65, 0x72, 0x18, 0x02,
+	0x20, 0x01, 0x28, 0x03, 0x52, 0x05, 0x6c, 0x6f, 0x77, 0x65, 0x72, 0x12, 0x16, 0x0a, 0x06, 0x6c,
+	0x61, 0x72, 0x67, 0x65, 0x72, 0x18, 0x03, 0x20, 0x01, 0x28, 0x03, 0x52, 0x06, 0x6c, 0x61, 0x72,
+	0x67, 0x65, 0x72, 0x12, 0x24, 0x0a, 0x0e, 0x6c, 0x6f, 0x77, 0x65, 0x72, 0x5f, 0x6f, 0x72, 0x5f,
+	0x65, 0x71, 0x75, 0x61, 0x6c, 0x18, 0x04, 0x20, 0x01, 0x28, 0x03, 0x52, 0x0c, 0x6c, 0x6f, 0x77,
+	0x65, 0x72, 0x4f, 0x72, 0x45, 0x71, 0x75, 0x61, 0x6c, 0x12, 0x26, 0x0a, 0x0f, 0x6c, 0x61, 0x72,
+	0x67, 0x65, 0x72, 0x5f, 0x6f, 0x72, 0x5f, 0x65, 0x71, 0x75, 0x61, 0x6c, 0x18, 0x05, 0x20, 0x01,
+	0x28, 0x03, 0x52, 0x0d, 0x6c, 0x61, 0x72, 0x67, 0x65, 0x72, 0x4f, 0x72, 0x45, 0x71, 0x75, 0x61,
+	0x6c, 0x12, 0x14, 0x0a, 0x05, 0x65, 0x71, 0x75, 0x61, 0x6c, 0x18, 0x06, 0x20, 0x01, 0x28, 0x03,
+	0x52, 0x05, 0x65, 0x71, 0x75, 0x61, 0x6c, 0x12, 0x19, 0x0a, 0x06, 0x69, 0x6e, 0x5f, 0x73, 0x65,
+	0x74, 0x18, 0x07, 0x20, 0x03, 0x28, 0x03, 0x42, 0x02, 0x10, 0x01, 0x52, 0x05, 0x69, 0x6e, 0x53,
+	0x65, 0x74, 0x12, 0x20, 0x0a, 0x0a, 0x6e, 0x6f, 0x74, 0x5f, 0x69, 0x6e, 0x5f, 0x73, 0x65, 0x74,
+	0x18, 0x08, 0x20, 0x03, 0x28, 0x03, 0x42, 0x02, 0x10, 0x01, 0x52, 0x08, 0x6e, 0x6f, 0x74, 0x49,
+	0x6e, 0x53, 0x65, 0x74, 0x22, 0x65, 0x0a, 0x04, 0x4b, 0x69, 0x6e, 0x64, 0x12, 0x09, 0x0a, 0x05,
+	0x4c, 0x4f, 0x57, 0x45, 0x52, 0x10, 0x00, 0x12, 0x0a, 0x0a, 0x06, 0x4c, 0x41, 0x52, 0x47, 0x45,
+	0x52, 0x10, 0x01, 0x12, 0x12, 0x0a, 0x0e, 0x4c, 0x4f, 0x57, 0x45, 0x52, 0x5f, 0x4f, 0x52, 0x5f,
+	0x45, 0x51, 0x55, 0x41, 0x4c, 0x10, 0x02, 0x12, 0x13, 0x0a, 0x0f, 0x4c, 0x41, 0x52, 0x47, 0x45,
+	0x52, 0x5f, 0x4f, 0x52, 0x5f, 0x45, 0x51, 0x55, 0x41, 0x4c, 0x10, 0x03, 0x12, 0x09, 0x0a, 0x05,
+	0x45, 0x51, 0x55, 0x41, 0x4c, 0x10, 0x04, 0x12, 0x06, 0x0a, 0x02, 0x49, 0x4e, 0x10, 0x05, 0x12,
+	0x0a, 0x0a, 0x06, 0x4e, 0x4f, 0x54, 0x5f, 0x49, 0x4e, 0x10, 0x06, 0x22, 0xf2, 0x02, 0x0a, 0x0f,
+	0x49, 0x6e, 0x74, 0x43, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74, 0x56, 0x31, 0x12,
+	0x29, 0x0a, 0x04, 0x6b, 0x69, 0x6e, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x15, 0x2e,
+	0x49, 0x6e, 0x74, 0x43, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74, 0x56, 0x31, 0x2e,
+	0x4b, 0x69, 0x6e, 0x64, 0x52, 0x04, 0x6b, 0x69, 0x6e, 0x64, 0x12, 0x14, 0x0a, 0x05, 0x6c, 0x6f,
+	0x77, 0x65, 0x72, 0x18, 0x02, 0x20, 0x01, 0x28, 0x03, 0x52, 0x05, 0x6c, 0x6f, 0x77, 0x65, 0x72,
+	0x12, 0x16, 0x0a, 0x06, 0x6c, 0x61, 0x72, 0x67, 0x65, 0x72, 0x18, 0x03, 0x20, 0x01, 0x28, 0x03,
+	0x52, 0x06, 0x6c, 0x61, 0x72, 0x67, 0x65, 0x72, 0x12, 0x24, 0x0a, 0x0e, 0x6c, 0x6f, 0x77, 0x65,
+	0x72, 0x5f, 0x6f, 0x72, 0x5f, 0x65, 0x71, 0x75, 0x61, 0x6c, 0x18, 0x04, 0x20, 0x01, 0x28, 0x03,
+	0x52, 0x0c, 0x6c, 0x6f, 0x77, 0x65, 0x72, 0x4f, 0x72, 0x45, 0x71, 0x75, 0x61, 0x6c, 0x12, 0x26,
+	0x0a, 0x0f, 0x6c, 0x61, 0x72, 0x67, 0x65, 0x72, 0x5f, 0x6f, 0x72, 0x5f, 0x65, 0x71, 0x75, 0x61,
+	0x6c, 0x18, 0x05, 0x20, 0x01, 0x28, 0x03, 0x52, 0x0d, 0x6c, 0x61, 0x72, 0x67, 0x65, 0x72, 0x4f,
+	0x72, 0x45, 0x71, 0x75, 0x61, 0x6c, 0x12, 0x14, 0x0a, 0x05, 0x65, 0x71, 0x75, 0x61, 0x6c, 0x18,
+	0x06, 0x20, 0x01, 0x28, 0x03, 0x52, 0x05, 0x65, 0x71, 0x75, 0x61, 0x6c, 0x12, 0x19, 0x0a, 0x06,
+	0x69, 0x6e, 0x5f, 0x73, 0x65, 0x74, 0x18, 0x07, 0x20, 0x03, 0x28, 0x03, 0x42, 0x02, 0x10, 0x01,
+	0x52, 0x05, 0x69, 0x6e, 0x53, 0x65, 0x74, 0x12, 0x20, 0x0a, 0x0a, 0x6e, 0x6f, 0x74, 0x5f, 0x69,
+	0x6e, 0x5f, 0x73, 0x65, 0x74, 0x18, 0x08, 0x20, 0x03, 0x28, 0x03, 0x42, 0x02, 0x10, 0x01, 0x52,
+	0x08, 0x6e, 0x6f, 0x74, 0x49, 0x6e, 0x53, 0x65, 0x74, 0x22, 0x65, 0x0a, 0x04, 0x4b, 0x69, 0x6e,
+	0x64, 0x12, 0x09, 0x0a, 0x05, 0x4c, 0x4f, 0x57, 0x45, 0x52, 0x10, 0x00, 0x12, 0x0a, 0x0a, 0x06,
+	0x4c, 0x41, 0x52, 0x47, 0x45, 0x52, 0x10, 0x01, 0x12, 0x12, 0x0a, 0x0e, 0x4c, 0x4f, 0x57, 0x45,
+	0x52, 0x5f, 0x4f, 0x52, 0x5f, 0x45, 0x51, 0x55, 0x41, 0x4c, 0x10, 0x02, 0x12, 0x13, 0x0a, 0x0f,
+	0x4c, 0x41, 0x52, 0x47, 0x45, 0x52, 0x5f, 0x4f, 0x52, 0x5f, 0x45, 0x51, 0x55, 0x41, 0x4c, 0x10,
+	0x03, 0x12, 0x09, 0x0a, 0x05, 0x45, 0x51, 0x55, 0x41, 0x4c, 0x10, 0x04, 0x12, 0x06, 0x0a, 0x02,
+	0x49, 0x4e, 0x10, 0x05, 0x12, 0x0a, 0x0a, 0x06, 0x4e, 0x4f, 0x54, 0x5f, 0x49, 0x4e, 0x10, 0x06,
+	0x22, 0x9d, 0x02, 0x0a, 0x12, 0x53, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x43, 0x6f, 0x6e, 0x73, 0x74,
+	0x72, 0x61, 0x69, 0x6e, 0x74, 0x56, 0x30, 0x12, 0x2c, 0x0a, 0x04, 0x6b, 0x69, 0x6e, 0x64, 0x18,
+	0x01, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x18, 0x2e, 0x53, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x43, 0x6f,
+	0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74, 0x56, 0x30, 0x2e, 0x4b, 0x69, 0x6e, 0x64, 0x52,
+	0x04, 0x6b, 0x69, 0x6e, 0x64, 0x12, 0x16, 0x0a, 0x06, 0x70, 0x72, 0x65, 0x66, 0x69, 0x78, 0x18,
+	0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x06, 0x70, 0x72, 0x65, 0x66, 0x69, 0x78, 0x12, 0x16, 0x0a,
+	0x06, 0x73, 0x75, 0x66, 0x66, 0x69, 0x78, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x06, 0x73,
+	0x75, 0x66, 0x66, 0x69, 0x78, 0x12, 0x14, 0x0a, 0x05, 0x65, 0x71, 0x75, 0x61, 0x6c, 0x18, 0x04,
+	0x20, 0x01, 0x28, 0x09, 0x52, 0x05, 0x65, 0x71, 0x75, 0x61, 0x6c, 0x12, 0x15, 0x0a, 0x06, 0x69,
+	0x6e, 0x5f, 0x73, 0x65, 0x74, 0x18, 0x05, 0x20, 0x03, 0x28, 0x09, 0x52, 0x05, 0x69, 0x6e, 0x53,
+	0x65, 0x74, 0x12, 0x1c, 0x0a, 0x0a, 0x6e, 0x6f, 0x74, 0x5f, 0x69, 0x6e, 0x5f, 0x73, 0x65, 0x74,
+	0x18, 0x06, 0x20, 0x03, 0x28, 0x09, 0x52, 0x08, 0x6e, 0x6f, 0x74, 0x49, 0x6e, 0x53, 0x65, 0x74,
+	0x12, 0x14, 0x0a, 0x05, 0x72, 0x65, 0x67, 0x65, 0x78, 0x18, 0x07, 0x20, 0x01, 0x28, 0x09, 0x52,
+	0x05, 0x72, 0x65, 0x67, 0x65, 0x78, 0x22, 0x48, 0x0a, 0x04, 0x4b, 0x69, 0x6e, 0x64, 0x12, 0x0a,
+	0x0a, 0x06, 0x50, 0x52, 0x45, 0x46, 0x49, 0x58, 0x10, 0x00, 0x12, 0x0a, 0x0a, 0x06, 0x53, 0x55,
+	0x46, 0x46, 0x49, 0x58, 0x10, 0x01, 0x12, 0x09, 0x0a, 0x05, 0x45, 0x51, 0x55, 0x41, 0x4c, 0x10,
+	0x02, 0x12, 0x06, 0x0a, 0x02, 0x49, 0x4e, 0x10, 0x03, 0x12, 0x0a, 0x0a, 0x06, 0x4e, 0x4f, 0x54,
+	0x5f, 0x49, 0x4e, 0x10, 0x04, 0x12, 0x09, 0x0a, 0x05, 0x52, 0x45, 0x47, 0x45, 0x58, 0x10, 0x05,
+	0x22, 0x9d, 0x02, 0x0a, 0x12, 0x53, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x43, 0x6f, 0x6e, 0x73, 0x74,
+	0x72, 0x61, 0x69, 0x6e, 0x74, 0x56, 0x31, 0x12, 0x2c, 0x0a, 0x04, 0x6b, 0x69, 0x6e, 0x64, 0x18,
+	0x01, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x18, 0x2e, 0x53, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x43, 0x6f,
+	0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74, 0x56, 0x31, 0x2e, 0x4b, 0x69, 0x6e, 0x64, 0x52,
+	0x04, 0x6b, 0x69, 0x6e, 0x64, 0x12, 0x16, 0x0a, 0x06, 0x70, 0x72, 0x65, 0x66, 0x69, 0x78, 0x18,
+	0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x06, 0x70, 0x72, 0x65, 0x66, 0x69, 0x78, 0x12, 0x16, 0x0a,
+	0x06, 0x73, 0x75, 0x66, 0x66, 0x69, 0x78, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x06, 0x73,
+	0x75, 0x66, 0x66, 0x69, 0x78, 0x12, 0x14, 0x0a, 0x05, 0x65, 0x71, 0x75, 0x61, 0x6c, 0x18, 0x04,
+	0x20, 0x01, 0x28, 0x09, 0x52, 0x05, 0x65, 0x71, 0x75, 0x61, 0x6c, 0x12, 0x15, 0x0a, 0x06, 0x69,
+	0x6e, 0x5f, 0x73, 0x65, 0x74, 0x18, 0x05, 0x20, 0x03, 0x28, 0x09, 0x52, 0x05, 0x69, 0x6e, 0x53,
+	0x65, 0x74, 0x12, 0x1c, 0x0a, 0x0a, 0x6e, 0x6f, 0x74, 0x5f, 0x69, 0x6e, 0x5f, 0x73, 0x65, 0x74,
+	0x18, 0x06, 0x20, 0x03, 0x28, 0x09, 0x52, 0x08, 0x6e, 0x6f, 0x74, 0x49, 0x6e, 0x53, 0x65, 0x74,
+	0x12, 0x14, 0x0a, 0x05, 0x72, 0x65, 0x67, 0x65, 0x78, 0x18, 0x07, 0x20, 0x01, 0x28, 0x09, 0x52,
+	0x05, 0x72, 0x65, 0x67, 0x65, 0x78, 0x22, 0x48, 0x0a, 0x04, 0x4b, 0x69, 0x6e, 0x64, 0x12, 0x0a,
+	0x0a, 0x06, 0x50, 0x52, 0x45, 0x46, 0x49, 0x58, 0x10, 0x00, 0x12, 0x0a, 0x0a, 0x06, 0x53, 0x55,
+	0x46, 0x46, 0x49, 0x58, 0x10, 0x01, 0x12, 0x09, 0x0a, 0x05, 0x45, 0x51, 0x55, 0x41, 0x4c, 0x10,
+	0x02, 0x12, 0x06, 0x0a, 0x02, 0x49, 0x4e, 0x10, 0x03, 0x12, 0x0a, 0x0a, 0x06, 0x4e, 0x4f, 0x54,
+	0x5f, 0x49, 0x4e, 0x10, 0x04, 0x12, 0x09, 0x0a, 0x05, 0x52, 0x45, 0x47, 0x45, 0x58, 0x10, 0x05,
+	0x22, 0x8b, 0x01, 0x0a, 0x10, 0x44, 0x61, 0x74, 0x65, 0x43, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61,
+	0x69, 0x6e, 0x74, 0x56, 0x30, 0x12, 0x2a, 0x0a, 0x04, 0x6b, 0x69, 0x6e, 0x64, 0x18, 0x01, 0x20,
+	0x01, 0x28, 0x0e, 0x32, 0x16, 0x2e, 0x44, 0x61, 0x74, 0x65, 0x43, 0x6f, 0x6e, 0x73, 0x74, 0x72,
+	0x61, 0x69, 0x6e, 0x74, 0x56, 0x30, 0x2e, 0x4b, 0x69, 0x6e, 0x64, 0x52, 0x04, 0x6b, 0x69, 0x6e,
+	0x64, 0x12, 0x16, 0x0a, 0x06, 0x62, 0x65, 0x66, 0x6f, 0x72, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28,
+	0x04, 0x52, 0x06, 0x62, 0x65, 0x66, 0x6f, 0x72, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x61, 0x66, 0x74,
+	0x65, 0x72, 0x18, 0x03, 0x20, 0x01, 0x28, 0x04, 0x52, 0x05, 0x61, 0x66, 0x74, 0x65, 0x72, 0x22,
+	0x1d, 0x0a, 0x04, 0x4b, 0x69, 0x6e, 0x64, 0x12, 0x0a, 0x0a, 0x06, 0x42, 0x45, 0x46, 0x4f, 0x52,
+	0x45, 0x10, 0x00, 0x12, 0x09, 0x0a, 0x05, 0x41, 0x46, 0x54, 0x45, 0x52, 0x10, 0x01, 0x22, 0x8b,
+	0x01, 0x0a, 0x10, 0x44, 0x61, 0x74, 0x65, 0x43, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e,
+	0x74, 0x56, 0x31, 0x12, 0x2a, 0x0a, 0x04, 0x6b, 0x69, 0x6e, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28,
+	0x0e, 0x32, 0x16, 0x2e, 0x44, 0x61, 0x74, 0x65, 0x43, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61, 0x69,
+	0x6e, 0x74, 0x56, 0x31, 0x2e, 0x4b, 0x69, 0x6e, 0x64, 0x52, 0x04, 0x6b, 0x69, 0x6e, 0x64, 0x12,
+	0x16, 0x0a, 0x06, 0x62, 0x65, 0x66, 0x6f, 0x72, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x04, 0x52,
+	0x06, 0x62, 0x65, 0x66, 0x6f, 0x72, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x61, 0x66, 0x74, 0x65, 0x72,
+	0x18, 0x03, 0x20, 0x01, 0x28, 0x04, 0x52, 0x05, 0x61, 0x66, 0x74, 0x65, 0x72, 0x22, 0x1d, 0x0a,
+	0x04, 0x4b, 0x69, 0x6e, 0x64, 0x12, 0x0a, 0x0a, 0x06, 0x42, 0x45, 0x46, 0x4f, 0x52, 0x45, 0x10,
+	0x00, 0x12, 0x09, 0x0a, 0x05, 0x41, 0x46, 0x54, 0x45, 0x52, 0x10, 0x01, 0x22, 0x93, 0x01, 0x0a,
+	0x12, 0x53, 0x79, 0x6d, 0x62, 0x6f, 0x6c, 0x43, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e,
+	0x74, 0x56, 0x30, 0x12, 0x2c, 0x0a, 0x04, 0x6b, 0x69, 0x6e, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28,
+	0x0e, 0x32, 0x18, 0x2e, 0x53, 0x79, 0x6d, 0x62, 0x6f, 0x6c, 0x43, 0x6f, 0x6e, 0x73, 0x74, 0x72,
+	0x61, 0x69, 0x6e, 0x74, 0x56, 0x30, 0x2e, 0x4b, 0x69, 0x6e, 0x64, 0x52, 0x04, 0x6b, 0x69, 0x6e,
+	0x64, 0x12, 0x15, 0x0a, 0x06, 0x69, 0x6e, 0x5f, 0x73, 0x65, 0x74, 0x18, 0x02, 0x20, 0x03, 0x28,
+	0x04, 0x52, 0x05, 0x69, 0x6e, 0x53, 0x65, 0x74, 0x12, 0x1c, 0x0a, 0x0a, 0x6e, 0x6f, 0x74, 0x5f,
+	0x69, 0x6e, 0x5f, 0x73, 0x65, 0x74, 0x18, 0x03, 0x20, 0x03, 0x28, 0x04, 0x52, 0x08, 0x6e, 0x6f,
+	0x74, 0x49, 0x6e, 0x53, 0x65, 0x74, 0x22, 0x1a, 0x0a, 0x04, 0x4b, 0x69, 0x6e, 0x64, 0x12, 0x06,
+	0x0a, 0x02, 0x49, 0x4e, 0x10, 0x00, 0x12, 0x0a, 0x0a, 0x06, 0x4e, 0x4f, 0x54, 0x5f, 0x49, 0x4e,
+	0x10, 0x01, 0x22, 0x93, 0x01, 0x0a, 0x12, 0x53, 0x79, 0x6d, 0x62, 0x6f, 0x6c, 0x43, 0x6f, 0x6e,
+	0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74, 0x56, 0x31, 0x12, 0x2c, 0x0a, 0x04, 0x6b, 0x69, 0x6e,
+	0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x18, 0x2e, 0x53, 0x79, 0x6d, 0x62, 0x6f, 0x6c,
+	0x43, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74, 0x56, 0x31, 0x2e, 0x4b, 0x69, 0x6e,
+	0x64, 0x52, 0x04, 0x6b, 0x69, 0x6e, 0x64, 0x12, 0x15, 0x0a, 0x06, 0x69, 0x6e, 0x5f, 0x73, 0x65,
+	0x74, 0x18, 0x02, 0x20, 0x03, 0x28, 0x04, 0x52, 0x05, 0x69, 0x6e, 0x53, 0x65, 0x74, 0x12, 0x1c,
+	0x0a, 0x0a, 0x6e, 0x6f, 0x74, 0x5f, 0x69, 0x6e, 0x5f, 0x73, 0x65, 0x74, 0x18, 0x03, 0x20, 0x03,
+	0x28, 0x04, 0x52, 0x08, 0x6e, 0x6f, 0x74, 0x49, 0x6e, 0x53, 0x65, 0x74, 0x22, 0x1a, 0x0a, 0x04,
+	0x4b, 0x69, 0x6e, 0x64, 0x12, 0x06, 0x0a, 0x02, 0x49, 0x4e, 0x10, 0x00, 0x12, 0x0a, 0x0a, 0x06,
+	0x4e, 0x4f, 0x54, 0x5f, 0x49, 0x4e, 0x10, 0x01, 0x22, 0xb2, 0x01, 0x0a, 0x11, 0x42, 0x79, 0x74,
+	0x65, 0x73, 0x43, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74, 0x56, 0x30, 0x12, 0x2b,
+	0x0a, 0x04, 0x6b, 0x69, 0x6e, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x17, 0x2e, 0x42,
+	0x79, 0x74, 0x65, 0x73, 0x43, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e, 0x74, 0x56, 0x30,
+	0x2e, 0x4b, 0x69, 0x6e, 0x64, 0x52, 0x04, 0x6b, 0x69, 0x6e, 0x64, 0x12, 0x14, 0x0a, 0x05, 0x65,
+	0x71, 0x75, 0x61, 0x6c, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0c, 0x52, 0x05, 0x65, 0x71, 0x75, 0x61,
+	0x6c, 0x12, 0x15, 0x0a, 0x06, 0x69, 0x6e, 0x5f, 0x73, 0x65, 0x74, 0x18, 0x03, 0x20, 0x03, 0x28,
+	0x0c, 0x52, 0x05, 0x69, 0x6e, 0x53, 0x65, 0x74, 0x12, 0x1c, 0x0a, 0x0a, 0x6e, 0x6f, 0x74, 0x5f,
+	0x69, 0x6e, 0x5f, 0x73, 0x65, 0x74, 0x18, 0x04, 0x20, 0x03, 0x28, 0x0c, 0x52, 0x08, 0x6e, 0x6f,
+	0x74, 0x49, 0x6e, 0x53, 0x65, 0x74, 0x22, 0x25, 0x0a, 0x04, 0x4b, 0x69, 0x6e, 0x64, 0x12, 0x09,
+	0x0a, 0x05, 0x45, 0x51, 0x55, 0x41, 0x4c, 0x10, 0x00, 0x12, 0x06, 0x0a, 0x02, 0x49, 0x4e, 0x10,
+	0x01, 0x12, 0x0a, 0x0a, 0x06, 0x4e, 0x4f, 0x54, 0x5f, 0x49, 0x4e, 0x10, 0x02, 0x22, 0xb2, 0x01,
+	0x0a, 0x11, 0x42, 0x79, 0x74, 0x65, 0x73, 0x43, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61, 0x69, 0x6e,
+	0x74, 0x56, 0x31, 0x12, 0x2b, 0x0a, 0x04, 0x6b, 0x69, 0x6e, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28,
+	0x0e, 0x32, 0x17, 0x2e, 0x42, 0x79, 0x74, 0x65, 0x73, 0x43, 0x6f, 0x6e, 0x73, 0x74, 0x72, 0x61,
+	0x69, 0x6e, 0x74, 0x56, 0x31, 0x2e, 0x4b, 0x69, 0x6e, 0x64, 0x52, 0x04, 0x6b, 0x69, 0x6e, 0x64,
+	0x12, 0x14, 0x0a, 0x05, 0x65, 0x71, 0x75, 0x61, 0x6c, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0c, 0x52,
+	0x05, 0x65, 0x71, 0x75, 0x61, 0x6c, 0x12, 0x15, 0x0a, 0x06, 0x69, 0x6e, 0x5f, 0x73, 0x65, 0x74,
+	0x18, 0x03, 0x20, 0x03, 0x28, 0x0c, 0x52, 0x05, 0x69, 0x6e, 0x53, 0x65, 0x74, 0x12, 0x1c, 0x0a,
+	0x0a, 0x6e, 0x6f, 0x74, 0x5f, 0x69, 0x6e, 0x5f, 0x73, 0x65, 0x74, 0x18, 0x04, 0x20, 0x03, 0x28,
+	0x0c, 0x52, 0x08, 0x6e, 0x6f, 0x74, 0x49, 0x6e, 0x53, 0x65, 0x74, 0x22, 0x25, 0x0a, 0x04, 0x4b,
+	0x69, 0x6e, 0x64, 0x12, 0x09, 0x0a, 0x05, 0x45, 0x51, 0x55, 0x41, 0x4c, 0x10, 0x00, 0x12, 0x06,
+	0x0a, 0x02, 0x49, 0x4e, 0x10, 0x01, 0x12, 0x0a, 0x0a, 0x06, 0x4e, 0x4f, 0x54, 0x5f, 0x49, 0x4e,
+	0x10, 0x02, 0x42, 0x06, 0x5a, 0x04, 0x2e, 0x3b, 0x70, 0x62, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74,
+	0x6f, 0x33,
 }
 
 var (
@@ -1668,61 +3017,101 @@ func file_biscuit_proto_rawDescGZIP() []byte {
 	return file_biscuit_proto_rawDescData
 }
 
-var file_biscuit_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
-var file_biscuit_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
+var file_biscuit_proto_enumTypes = make([]protoimpl.EnumInfo, 14)
+var file_biscuit_proto_msgTypes = make([]protoimpl.MessageInfo, 26)
 var file_biscuit_proto_goTypes = []interface{}{
-	(ID_Kind)(0),               // 0: ID.Kind
-	(Constraint_Kind)(0),       // 1: Constraint.Kind
-	(IntConstraint_Kind)(0),    // 2: IntConstraint.Kind
-	(StringConstraint_Kind)(0), // 3: StringConstraint.Kind
-	(DateConstraint_Kind)(0),   // 4: DateConstraint.Kind
-	(SymbolConstraint_Kind)(0), // 5: SymbolConstraint.Kind
-	(BytesConstraint_Kind)(0),  // 6: BytesConstraint.Kind
-	(*Biscuit)(nil),            // 7: Biscuit
-	(*SealedBiscuit)(nil),      // 8: SealedBiscuit
-	(*Signature)(nil),          // 9: Signature
-	(*Block)(nil),              // 10: Block
-	(*Fact)(nil),               // 11: Fact
-	(*Rule)(nil),               // 12: Rule
-	(*Caveat)(nil),             // 13: Caveat
-	(*Predicate)(nil),          // 14: Predicate
-	(*ID)(nil),                 // 15: ID
-	(*Constraint)(nil),         // 16: Constraint
-	(*IntConstraint)(nil),      // 17: IntConstraint
-	(*StringConstraint)(nil),   // 18: StringConstraint
-	(*DateConstraint)(nil),     // 19: DateConstraint
-	(*SymbolConstraint)(nil),   // 20: SymbolConstraint
-	(*BytesConstraint)(nil),    // 21: BytesConstraint
+	(IDV0_Kind)(0),               // 0: IDV0.Kind
+	(IDV1_Kind)(0),               // 1: IDV1.Kind
+	(ConstraintV0_Kind)(0),       // 2: ConstraintV0.Kind
+	(ConstraintV1_Kind)(0),       // 3: ConstraintV1.Kind
+	(IntConstraintV0_Kind)(0),    // 4: IntConstraintV0.Kind
+	(IntConstraintV1_Kind)(0),    // 5: IntConstraintV1.Kind
+	(StringConstraintV0_Kind)(0), // 6: StringConstraintV0.Kind
+	(StringConstraintV1_Kind)(0), // 7: StringConstraintV1.Kind
+	(DateConstraintV0_Kind)(0),   // 8: DateConstraintV0.Kind
+	(DateConstraintV1_Kind)(0),   // 9: DateConstraintV1.Kind
+	(SymbolConstraintV0_Kind)(0), // 10: SymbolConstraintV0.Kind
+	(SymbolConstraintV1_Kind)(0), // 11: SymbolConstraintV1.Kind
+	(BytesConstraintV0_Kind)(0),  // 12: BytesConstraintV0.Kind
+	(BytesConstraintV1_Kind)(0),  // 13: BytesConstraintV1.Kind
+	(*Biscuit)(nil),              // 14: Biscuit
+	(*SealedBiscuit)(nil),        // 15: SealedBiscuit
+	(*Signature)(nil),            // 16: Signature
+	(*Block)(nil),                // 17: Block
+	(*FactV0)(nil),               // 18: FactV0
+	(*FactV1)(nil),               // 19: FactV1
+	(*RuleV0)(nil),               // 20: RuleV0
+	(*RuleV1)(nil),               // 21: RuleV1
+	(*CaveatV0)(nil),             // 22: CaveatV0
+	(*CaveatV1)(nil),             // 23: CaveatV1
+	(*PredicateV0)(nil),          // 24: PredicateV0
+	(*PredicateV1)(nil),          // 25: PredicateV1
+	(*IDV0)(nil),                 // 26: IDV0
+	(*IDV1)(nil),                 // 27: IDV1
+	(*ConstraintV0)(nil),         // 28: ConstraintV0
+	(*ConstraintV1)(nil),         // 29: ConstraintV1
+	(*IntConstraintV0)(nil),      // 30: IntConstraintV0
+	(*IntConstraintV1)(nil),      // 31: IntConstraintV1
+	(*StringConstraintV0)(nil),   // 32: StringConstraintV0
+	(*StringConstraintV1)(nil),   // 33: StringConstraintV1
+	(*DateConstraintV0)(nil),     // 34: DateConstraintV0
+	(*DateConstraintV1)(nil),     // 35: DateConstraintV1
+	(*SymbolConstraintV0)(nil),   // 36: SymbolConstraintV0
+	(*SymbolConstraintV1)(nil),   // 37: SymbolConstraintV1
+	(*BytesConstraintV0)(nil),    // 38: BytesConstraintV0
+	(*BytesConstraintV1)(nil),    // 39: BytesConstraintV1
 }
 var file_biscuit_proto_depIdxs = []int32{
-	9,  // 0: Biscuit.signature:type_name -> Signature
-	11, // 1: Block.facts:type_name -> Fact
-	12, // 2: Block.rules:type_name -> Rule
-	13, // 3: Block.caveats:type_name -> Caveat
-	14, // 4: Fact.predicate:type_name -> Predicate
-	14, // 5: Rule.head:type_name -> Predicate
-	14, // 6: Rule.body:type_name -> Predicate
-	16, // 7: Rule.constraints:type_name -> Constraint
-	12, // 8: Caveat.queries:type_name -> Rule
-	15, // 9: Predicate.ids:type_name -> ID
-	0,  // 10: ID.kind:type_name -> ID.Kind
-	15, // 11: ID.set:type_name -> ID
-	1,  // 12: Constraint.kind:type_name -> Constraint.Kind
-	17, // 13: Constraint.int:type_name -> IntConstraint
-	18, // 14: Constraint.str:type_name -> StringConstraint
-	19, // 15: Constraint.date:type_name -> DateConstraint
-	20, // 16: Constraint.symbol:type_name -> SymbolConstraint
-	21, // 17: Constraint.bytes:type_name -> BytesConstraint
-	2,  // 18: IntConstraint.kind:type_name -> IntConstraint.Kind
-	3,  // 19: StringConstraint.kind:type_name -> StringConstraint.Kind
-	4,  // 20: DateConstraint.kind:type_name -> DateConstraint.Kind
-	5,  // 21: SymbolConstraint.kind:type_name -> SymbolConstraint.Kind
-	6,  // 22: BytesConstraint.kind:type_name -> BytesConstraint.Kind
-	23, // [23:23] is the sub-list for method output_type
-	23, // [23:23] is the sub-list for method input_type
-	23, // [23:23] is the sub-list for extension type_name
-	23, // [23:23] is the sub-list for extension extendee
-	0,  // [0:23] is the sub-list for field type_name
+	16, // 0: Biscuit.signature:type_name -> Signature
+	18, // 1: Block.facts_v0:type_name -> FactV0
+	20, // 2: Block.rules_v0:type_name -> RuleV0
+	22, // 3: Block.caveats_v0:type_name -> CaveatV0
+	19, // 4: Block.facts_v1:type_name -> FactV1
+	21, // 5: Block.rules_v1:type_name -> RuleV1
+	23, // 6: Block.caveats_v1:type_name -> CaveatV1
+	24, // 7: FactV0.predicate:type_name -> PredicateV0
+	25, // 8: FactV1.predicate:type_name -> PredicateV1
+	24, // 9: RuleV0.head:type_name -> PredicateV0
+	24, // 10: RuleV0.body:type_name -> PredicateV0
+	28, // 11: RuleV0.constraints:type_name -> ConstraintV0
+	25, // 12: RuleV1.head:type_name -> PredicateV1
+	25, // 13: RuleV1.body:type_name -> PredicateV1
+	29, // 14: RuleV1.constraints:type_name -> ConstraintV1
+	20, // 15: CaveatV0.queries:type_name -> RuleV0
+	21, // 16: CaveatV1.queries:type_name -> RuleV1
+	26, // 17: PredicateV0.ids:type_name -> IDV0
+	27, // 18: PredicateV1.ids:type_name -> IDV1
+	0,  // 19: IDV0.kind:type_name -> IDV0.Kind
+	26, // 20: IDV0.set:type_name -> IDV0
+	1,  // 21: IDV1.kind:type_name -> IDV1.Kind
+	27, // 22: IDV1.set:type_name -> IDV1
+	2,  // 23: ConstraintV0.kind:type_name -> ConstraintV0.Kind
+	30, // 24: ConstraintV0.int:type_name -> IntConstraintV0
+	32, // 25: ConstraintV0.str:type_name -> StringConstraintV0
+	34, // 26: ConstraintV0.date:type_name -> DateConstraintV0
+	36, // 27: ConstraintV0.symbol:type_name -> SymbolConstraintV0
+	38, // 28: ConstraintV0.bytes:type_name -> BytesConstraintV0
+	3,  // 29: ConstraintV1.kind:type_name -> ConstraintV1.Kind
+	31, // 30: ConstraintV1.int:type_name -> IntConstraintV1
+	33, // 31: ConstraintV1.str:type_name -> StringConstraintV1
+	35, // 32: ConstraintV1.date:type_name -> DateConstraintV1
+	37, // 33: ConstraintV1.symbol:type_name -> SymbolConstraintV1
+	39, // 34: ConstraintV1.bytes:type_name -> BytesConstraintV1
+	4,  // 35: IntConstraintV0.kind:type_name -> IntConstraintV0.Kind
+	5,  // 36: IntConstraintV1.kind:type_name -> IntConstraintV1.Kind
+	6,  // 37: StringConstraintV0.kind:type_name -> StringConstraintV0.Kind
+	7,  // 38: StringConstraintV1.kind:type_name -> StringConstraintV1.Kind
+	8,  // 39: DateConstraintV0.kind:type_name -> DateConstraintV0.Kind
+	9,  // 40: DateConstraintV1.kind:type_name -> DateConstraintV1.Kind
+	10, // 41: SymbolConstraintV0.kind:type_name -> SymbolConstraintV0.Kind
+	11, // 42: SymbolConstraintV1.kind:type_name -> SymbolConstraintV1.Kind
+	12, // 43: BytesConstraintV0.kind:type_name -> BytesConstraintV0.Kind
+	13, // 44: BytesConstraintV1.kind:type_name -> BytesConstraintV1.Kind
+	45, // [45:45] is the sub-list for method output_type
+	45, // [45:45] is the sub-list for method input_type
+	45, // [45:45] is the sub-list for extension type_name
+	45, // [45:45] is the sub-list for extension extendee
+	0,  // [0:45] is the sub-list for field type_name
 }
 
 func init() { file_biscuit_proto_init() }
@@ -1780,7 +3169,7 @@ func file_biscuit_proto_init() {
 			}
 		}
 		file_biscuit_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*Fact); i {
+			switch v := v.(*FactV0); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1792,7 +3181,7 @@ func file_biscuit_proto_init() {
 			}
 		}
 		file_biscuit_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*Rule); i {
+			switch v := v.(*FactV1); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1804,7 +3193,7 @@ func file_biscuit_proto_init() {
 			}
 		}
 		file_biscuit_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*Caveat); i {
+			switch v := v.(*RuleV0); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1816,7 +3205,7 @@ func file_biscuit_proto_init() {
 			}
 		}
 		file_biscuit_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*Predicate); i {
+			switch v := v.(*RuleV1); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1828,7 +3217,7 @@ func file_biscuit_proto_init() {
 			}
 		}
 		file_biscuit_proto_msgTypes[8].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*ID); i {
+			switch v := v.(*CaveatV0); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1840,7 +3229,7 @@ func file_biscuit_proto_init() {
 			}
 		}
 		file_biscuit_proto_msgTypes[9].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*Constraint); i {
+			switch v := v.(*CaveatV1); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1852,7 +3241,7 @@ func file_biscuit_proto_init() {
 			}
 		}
 		file_biscuit_proto_msgTypes[10].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*IntConstraint); i {
+			switch v := v.(*PredicateV0); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1864,7 +3253,7 @@ func file_biscuit_proto_init() {
 			}
 		}
 		file_biscuit_proto_msgTypes[11].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*StringConstraint); i {
+			switch v := v.(*PredicateV1); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1876,7 +3265,7 @@ func file_biscuit_proto_init() {
 			}
 		}
 		file_biscuit_proto_msgTypes[12].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*DateConstraint); i {
+			switch v := v.(*IDV0); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1888,7 +3277,7 @@ func file_biscuit_proto_init() {
 			}
 		}
 		file_biscuit_proto_msgTypes[13].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*SymbolConstraint); i {
+			switch v := v.(*IDV1); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1900,7 +3289,139 @@ func file_biscuit_proto_init() {
 			}
 		}
 		file_biscuit_proto_msgTypes[14].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*BytesConstraint); i {
+			switch v := v.(*ConstraintV0); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_biscuit_proto_msgTypes[15].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*ConstraintV1); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_biscuit_proto_msgTypes[16].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*IntConstraintV0); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_biscuit_proto_msgTypes[17].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*IntConstraintV1); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_biscuit_proto_msgTypes[18].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*StringConstraintV0); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_biscuit_proto_msgTypes[19].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*StringConstraintV1); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_biscuit_proto_msgTypes[20].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*DateConstraintV0); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_biscuit_proto_msgTypes[21].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*DateConstraintV1); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_biscuit_proto_msgTypes[22].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*SymbolConstraintV0); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_biscuit_proto_msgTypes[23].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*SymbolConstraintV1); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_biscuit_proto_msgTypes[24].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*BytesConstraintV0); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_biscuit_proto_msgTypes[25].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*BytesConstraintV1); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1917,8 +3438,8 @@ func file_biscuit_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_biscuit_proto_rawDesc,
-			NumEnums:      7,
-			NumMessages:   15,
+			NumEnums:      14,
+			NumMessages:   26,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pb/biscuit.proto
+++ b/pb/biscuit.proto
@@ -23,29 +23,47 @@ message Signature {
 message Block {
   uint32 index = 1;
   repeated string symbols = 2;
-  repeated Fact facts = 3;
-  repeated Rule rules = 4;
-  repeated Caveat caveats = 5;
+  repeated FactV0 facts_v0 = 3;
+  repeated RuleV0 rules_v0 = 4;
+  repeated CaveatV0 caveats_v0 = 5;
   string context = 6;
   uint32 version = 7;
+  repeated FactV1 facts_v1 = 8;
+  repeated RuleV1 rules_v1 = 9;
+  repeated CaveatV1 caveats_v1 = 10;
 }
 
-message Fact { Predicate predicate = 1; }
+message FactV0 { PredicateV0 predicate = 1; }
 
-message Rule {
-  Predicate head = 1;
-  repeated Predicate body = 2;
-  repeated Constraint constraints = 3;
+message FactV1 { PredicateV1 predicate = 1; }
+
+message RuleV0 {
+  PredicateV0 head = 1;
+  repeated PredicateV0 body = 2;
+  repeated ConstraintV0 constraints = 3;
 }
 
-message Caveat { repeated Rule queries = 1; }
+message RuleV1 {
+  PredicateV1 head = 1;
+  repeated PredicateV1 body = 2;
+  repeated ConstraintV1 constraints = 3;
+}
 
-message Predicate {
+message CaveatV0 { repeated RuleV0 queries = 1; }
+
+message CaveatV1 { repeated RuleV1 queries = 1; }
+
+message PredicateV0 {
   uint64 name = 1;
-  repeated ID ids = 2;
+  repeated IDV0 ids = 2;
 }
 
-message ID {
+message PredicateV1 {
+  uint64 name = 1;
+  repeated IDV1 ids = 2;
+}
+
+message IDV0 {
   enum Kind {
     SYMBOL = 0;
     VARIABLE = 1;
@@ -63,10 +81,31 @@ message ID {
   string str = 5;
   uint64 date = 6;
   bytes bytes = 7;
-  repeated ID set = 8;
+  repeated IDV0 set = 8;
 }
 
-message Constraint {
+message IDV1 {
+  enum Kind {
+    SYMBOL = 0;
+    VARIABLE = 1;
+    INTEGER = 2;
+    STR = 3;
+    DATE = 4;
+    BYTES = 5;
+    SET = 6;
+  }
+
+  Kind kind = 1;
+  uint64 symbol = 2;
+  uint32 variable = 3;
+  int64 integer = 4;
+  string str = 5;
+  uint64 date = 6;
+  bytes bytes = 7;
+  repeated IDV1 set = 8;
+}
+
+message ConstraintV0 {
   uint32 id = 1;
 
   enum Kind {
@@ -80,14 +119,35 @@ message Constraint {
 
   Kind kind = 2;
 
-  IntConstraint int = 3;
-  StringConstraint str = 4;
-  DateConstraint date = 5;
-  SymbolConstraint symbol = 6;
-  BytesConstraint bytes = 7;
+  IntConstraintV0 int = 3;
+  StringConstraintV0 str = 4;
+  DateConstraintV0 date = 5;
+  SymbolConstraintV0 symbol = 6;
+  BytesConstraintV0 bytes = 7;
 }
 
-message IntConstraint {
+message ConstraintV1 {
+  uint32 id = 1;
+
+  enum Kind {
+    INT = 0;
+    STRING = 1;
+    DATE = 2;
+    SYMBOL = 3;
+    BYTES = 4;
+    SET = 5;
+  }
+
+  Kind kind = 2;
+
+  IntConstraintV1 int = 3;
+  StringConstraintV1 str = 4;
+  DateConstraintV1 date = 5;
+  SymbolConstraintV1 symbol = 6;
+  BytesConstraintV1 bytes = 7;
+}
+
+message IntConstraintV0 {
   enum Kind {
     LOWER = 0;
     LARGER = 1;
@@ -109,7 +169,29 @@ message IntConstraint {
   repeated int64 not_in_set = 8 [ packed = true ];
 }
 
-message StringConstraint {
+message IntConstraintV1 {
+  enum Kind {
+    LOWER = 0;
+    LARGER = 1;
+    LOWER_OR_EQUAL = 2;
+    LARGER_OR_EQUAL = 3;
+    EQUAL = 4;
+    IN = 5;
+    NOT_IN = 6;
+  }
+
+  Kind kind = 1;
+
+  int64 lower = 2;
+  int64 larger = 3;
+  int64 lower_or_equal = 4;
+  int64 larger_or_equal = 5;
+  int64 equal = 6;
+  repeated int64 in_set = 7 [ packed = true ];
+  repeated int64 not_in_set = 8 [ packed = true ];
+}
+
+message StringConstraintV0 {
   enum Kind {
     PREFIX = 0;
     SUFFIX = 1;
@@ -129,7 +211,27 @@ message StringConstraint {
   string regex = 7;
 }
 
-message DateConstraint {
+message StringConstraintV1 {
+  enum Kind {
+    PREFIX = 0;
+    SUFFIX = 1;
+    EQUAL = 2;
+    IN = 3;
+    NOT_IN = 4;
+    REGEX = 5;
+  }
+
+  Kind kind = 1;
+
+  string prefix = 2;
+  string suffix = 3;
+  string equal = 4;
+  repeated string in_set = 5;
+  repeated string not_in_set = 6;
+  string regex = 7;
+}
+
+message DateConstraintV0 {
   enum Kind {
     BEFORE = 0;
     AFTER = 1;
@@ -141,7 +243,19 @@ message DateConstraint {
   uint64 after = 3;
 }
 
-message SymbolConstraint {
+message DateConstraintV1 {
+  enum Kind {
+    BEFORE = 0;
+    AFTER = 1;
+  }
+
+  Kind kind = 1;
+
+  uint64 before = 2;
+  uint64 after = 3;
+}
+
+message SymbolConstraintV0 {
   enum Kind {
     IN = 0;
     NOT_IN = 1;
@@ -153,7 +267,33 @@ message SymbolConstraint {
   repeated uint64 not_in_set = 3;
 }
 
-message BytesConstraint {
+message SymbolConstraintV1 {
+  enum Kind {
+    IN = 0;
+    NOT_IN = 1;
+  }
+
+  Kind kind = 1;
+
+  repeated uint64 in_set = 2;
+  repeated uint64 not_in_set = 3;
+}
+
+message BytesConstraintV0 {
+  enum Kind {
+    EQUAL = 0;
+    IN = 1;
+    NOT_IN = 2;
+  }
+
+  Kind kind = 1;
+
+  bytes equal = 2;
+  repeated bytes in_set = 3;
+  repeated bytes not_in_set = 4;
+}
+
+message BytesConstraintV1 {
   enum Kind {
     EQUAL = 0;
     IN = 1;

--- a/types.go
+++ b/types.go
@@ -13,7 +13,7 @@ import (
 
 const SymbolAuthority = Symbol("authority")
 
-const MaxSchemaVersion uint32 = 0
+const MaxSchemaVersion uint32 = 1
 
 // defaultSymbolTable predefines some symbols available in every implementation, to avoid
 // transmitting them with every token


### PR DESCRIPTION
This split the current protobuf schema into a v0 and v1 schema.
They are equivalent for now, but v0 is considered frozen, and v1 is free to
change with no BC guarantees.

New generated tokens will now hold v1 blocks, meaning they could not be
parsed by a v0 library. But older v0 tokens are still compatible with the v1
library.