### PR TITLE
fix date comparison parsing

### DIFF
--- a/parser/GRAMMAR.md
+++ b/parser/GRAMMAR.md
@@ -43,8 +43,8 @@ Constraints allows performing checks on a variable, below is the list of availab
 
 ### Date
 
-- Before: `$date < "2006-01-02T15:04:05Z07:00"`
-- After: `$date > "2006-01-02T15:04:05Z07:00"`
+- Before: `$date <= "2006-01-02T15:04:05Z07:00"`
+- After: `$date >= "2006-01-02T15:04:05Z07:00"`
 
 ### Symbols
 

--- a/parser/grammar.go
+++ b/parser/grammar.go
@@ -114,7 +114,7 @@ type BytesComparison struct {
 }
 
 type DateComparison struct {
-	Operation *string `@("<" | ">")`
+	Operation *string `@("<=" | ">=")`
 	Target    *string `@String`
 }
 
@@ -240,12 +240,12 @@ func (c *VariableConstraint) ToBiscuit() (*biscuit.Constraint, error) {
 			return nil, err
 		}
 		switch *c.Date.Operation {
-		case "<":
+		case "<=":
 			constraint.Checker = biscuit.DateComparisonChecker{
 				Comparison: datalog.DateComparisonBefore,
 				Date:       biscuit.Date(date),
 			}
-		case ">":
+		case ">=":
 			constraint.Checker = biscuit.DateComparisonChecker{
 				Comparison: datalog.DateComparisonAfter,
 				Date:       biscuit.Date(date),

--- a/parser/grammar_test.go
+++ b/parser/grammar_test.go
@@ -258,24 +258,24 @@ func TestGrammarConstraint(t *testing.T) {
 			},
 		},
 		{
-			Input: `$0 < "2006-01-02T15:04:05Z07:00"`,
+			Input: `$0 <= "2006-01-02T15:04:05Z07:00"`,
 			Expected: &Constraint{
 				VariableConstraint: &VariableConstraint{
 					Variable: varptr("0"),
 					Date: &DateComparison{
-						Operation: sptr("<"),
+						Operation: sptr("<="),
 						Target:    sptr("2006-01-02T15:04:05Z07:00"),
 					},
 				},
 			},
 		},
 		{
-			Input: `$0 > "2006-01-02T15:04:05Z07:00"`,
+			Input: `$0 >= "2006-01-02T15:04:05Z07:00"`,
 			Expected: &Constraint{
 				VariableConstraint: &VariableConstraint{
 					Variable: varptr("0"),
 					Date: &DateComparison{
-						Operation: sptr(">"),
+						Operation: sptr(">="),
 						Target:    sptr("2006-01-02T15:04:05Z07:00"),
 					},
 				},

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -136,7 +136,7 @@ func getRuleTestCases() []testCase {
 			},
 		},
 		{
-			Input: fmt.Sprintf(`rule1(#a) <- body1(#b) @ $0 > "%s", $0 < "%s"`, t1.Format(time.RFC3339), t2.Format(time.RFC3339)),
+			Input: fmt.Sprintf(`rule1(#a) <- body1(#b) @ $0 >= "%s", $0 <= "%s"`, t1.Format(time.RFC3339), t2.Format(time.RFC3339)),
 			Expected: biscuit.Rule{
 				Head: biscuit.Predicate{
 					Name: "rule1",
@@ -165,7 +165,7 @@ func getRuleTestCases() []testCase {
 			},
 		},
 		{
-			Input:         fmt.Sprintf(`rule1(#a) <- body1(#b) @ $0 > "%s"`, t1.Format(time.RFC1123)),
+			Input:         fmt.Sprintf(`rule1(#a) <- body1(#b) @ $0 >= "%s"`, t1.Format(time.RFC1123)),
 			ExpectFailure: true,
 		},
 		{


### PR DESCRIPTION
Date comparisons currently accept ">" and "<" operators, but the
comparison is done with ">=" and "<=". As per the spec, it must be the
latter, so the parser now enforce the usage of ">=" and "<=" for date
comparisons.